### PR TITLE
Support East Asian Ambiguous Widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Usage of powerline-go:
   -cwd-mode string
         How to display the current directory
         (default "fancy")
+  -east-asian-width
+        Use East Asian Ambiguous Widths
   -error int
         Exit code of previously executed command
   -mode string

--- a/main.go
+++ b/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"strings"
-	"flag"
 )
 
 type segment struct {
@@ -20,6 +20,7 @@ type args struct {
 	CwdMaxDepth      *int
 	CwdMaxDirSize    *int
 	ColorizeHostname *bool
+	EastAsianWidth   *bool
 	Mode             *string
 	Shell            *string
 	Modules          *string
@@ -87,6 +88,8 @@ func main() {
 				"       "),
 		ColorizeHostname: flag.Bool("colorize-hostname", false,
 			"Colorize the hostname based on a hash of itself"),
+		EastAsianWidth: flag.Bool("east-asian-width", false,
+			"Use East Asian Ambiguous Widths"),
 		Mode: flag.String("mode", "patched",
 			"The characters used to make separators between segments.\n"+
 				"    	(valid choices: patched, compatible, flat)\n"+

--- a/powerline.go
+++ b/powerline.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"fmt"
 	"bytes"
+	"fmt"
+	"golang.org/x/text/width"
 )
 
 type powerline struct {
@@ -77,5 +78,20 @@ func (p *powerline) draw() string {
 		buffer.WriteString(p.reset)
 	}
 	buffer.WriteString(" ")
-	return buffer.String()
+
+	s := buffer.String()
+	if *p.args.EastAsianWidth {
+		for _, r := range s {
+			switch width.LookupRune(r).Kind() {
+			case width.Neutral:
+			case width.EastAsianAmbiguous:
+				s += " "
+			case width.EastAsianWide:
+			case width.EastAsianNarrow:
+			case width.EastAsianFullwidth:
+			case width.EastAsianHalfwidth:
+			}
+		}
+	}
+	return s
 }


### PR DESCRIPTION
There are some letters which is marked as ambiguous width in east asian. For example `` is this. If terminal render that letters as double width, the powerline goes cursor wrong place like below.

![a0375e13f1b819c7](https://user-images.githubusercontent.com/10111/29550979-94ed93ba-874b-11e7-8a2c-20f13f87d27a.png)

This PR add flag `-east-asian-width` to fix this problem.

![d3626b1923e02c9e](https://user-images.githubusercontent.com/10111/29550977-918ba89c-874b-11e7-836a-7e61251504f3.png)

