### PR TITLE
Add a feature to ignore git repos, specified by root dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ type args struct {
 	Modules            *string
 	Priority           *string
 	MaxWidthPercentage *int
+	IgnoreRepos      *string
 	PrevError          *int
 }
 
@@ -126,6 +127,10 @@ func main() {
 				"       "),
 		PrevError: flag.Int("error", 0,
 			"Exit code of previously executed command"),
+		IgnoreRepos: flag.String("ignore-repos",
+			"",
+			"A list of git repos to ignore. Separate with ','\n"+
+				"Repos are identified by their root directory."),
 	}
 	flag.Parse()
 	priorities := map[string]int{}

--- a/powerline.go
+++ b/powerline.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"strings"
+
 	"golang.org/x/text/width"
 	"math"
 	"os"
@@ -25,6 +27,7 @@ type powerline struct {
 	reset           string
 	symbolTemplates Symbols
 	priorities      map[string]int
+	ignoreRepos     map[string]bool
 	Segments        []segment
 }
 
@@ -37,6 +40,10 @@ func NewPowerline(args args, cwd string, priorities map[string]int) *powerline {
 	p.reset = fmt.Sprintf(p.shellInfo.colorTemplate, "[0m")
 	p.symbolTemplates = symbolTemplates[*args.Mode]
 	p.priorities = priorities
+	p.ignoreRepos = make(map[string]bool)
+	for _, r := range strings.Split(*args.IgnoreRepos, ",") {
+		p.ignoreRepos[r] = true
+	}
 	p.Segments = make([]segment, 0)
 	return p
 }


### PR DESCRIPTION
I have a git repo checked out to my home dir for my dot files. I find it quite
distracting to be told about its status in *every* directory I'm in that's not
another git repo.