### PR TITLE
Add lightweight Git support

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ type args struct {
 	Modules            *string
 	Priority           *string
 	MaxWidthPercentage *int
-	IgnoreRepos      *string
+	IgnoreRepos        *string
 	PrevError          *int
 }
 
@@ -71,6 +71,7 @@ var modules = map[string](func(*powerline)){
 	"docker":   segmentDocker,
 	"exit":     segmentExitCode,
 	"git":      segmentGit,
+	"gitlite":  segmentGitLite,
 	"hg":       segmentHg,
 	"host":     segmentHost,
 	"jobs":     segmentJobs,
@@ -115,7 +116,7 @@ func main() {
 		Modules: flag.String("modules",
 			"venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root",
 			"The list of modules to load. Separate with ','\n"+
-				"    	(valid choices: cwd, docker, exit, git, hg, host, jobs, perlbrew, perms, root, ssh, time, user, venv)\n"+
+				"    	(valid choices: cwd, docker, exit, git, gitlite, hg, host, jobs, perlbrew, perms, root, ssh, time, user, venv)\n"+
 				"       "),
 		Priority: flag.String("priority",
 			"root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit",

--- a/segment-gitlite.go
+++ b/segment-gitlite.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+func segmentGitLite(p *powerline) {
+	if len(p.ignoreRepos) > 0 {
+		out, err := runGitCommand("git", "rev-parse", "--show-toplevel")
+		if err != nil {
+			return
+		}
+		out = strings.TrimSpace(out)
+		if p.ignoreRepos[out] {
+			return
+		}
+	}
+
+	out, err := runGitCommand("git", "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return
+	}
+
+	status := strings.TrimSpace(out)
+	var branch string
+
+	if status != "HEAD" {
+		branch = status
+	} else {
+		branch = getGitDetachedBranch(p)
+	}
+
+	p.appendSegment("git-branch", segment{
+		content:    fmt.Sprintf(" %s ", branch),
+		foreground: p.theme.RepoCleanFg,
+		background: p.theme.RepoCleanBg,
+	})
+}


### PR DESCRIPTION
The main Git segment calls git status which can take several seconds on
a large repository on NFS.  The newly added gitlite segment only attempts to
grab the branch name (or SHA for detatched heads) and ignores dirty
state.