### PR TITLE
Support for keymap highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ function install_powerline_precmd() {
 if [ "$TERM" != "linux" ]; then
     install_powerline_precmd
 fi
+
+function zle-line-init zle-keymap-select {
+    export KEYMAP_POWERLINE=$KEYMAP
+    powerline_precmd
+    zle reset-prompt
+}
+
+zle -N zle-line-init
+zle -N zle-keymap-select
 ```
 
 ### Fish

--- a/main.go
+++ b/main.go
@@ -82,6 +82,7 @@ var modules = map[string](func(*powerline)){
 	"time":     segmentTime,
 	"user":     segmentUser,
 	"venv":     segmentVirtualEnv,
+	"keymap":   segmentKeymap,
 }
 
 func main() {

--- a/segment-keymap.go
+++ b/segment-keymap.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+)
+
+func segmentKeymap(p *powerline) {
+	var keymap string
+	var present bool
+	if keymap == "" {
+		keymap, present = os.LookupEnv("KEYMAP_POWERLINE")
+	}
+	if !present {
+		keymap = "ouch"
+	}
+	if keymap == "main" {
+		p.appendSegment("keymap", segment{
+			content:    " I ",
+			foreground: p.theme.RepoDirtyFg,
+			background: p.theme.RepoDirtyBg,
+		})
+	}
+	if keymap == "vicmd" {
+		p.appendSegment("keymap", segment{
+			content:    " C ",
+			foreground: p.theme.RepoCleanFg,
+			background: p.theme.RepoCleanBg,
+		})
+	}
+
+}

--- a/segment-keymap.go
+++ b/segment-keymap.go
@@ -4,28 +4,28 @@ import (
 	"os"
 )
 
+var editSegment = segment{
+	content:    "\u270E",
+	foreground: 15,
+	background: 161,
+}
+
+var commandSegment = segment{
+	content:    "\u26CF",
+	foreground: 15,
+	background: 31,
+}
+
 func segmentKeymap(p *powerline) {
 	var keymap string
-	var present bool
 	if keymap == "" {
-		keymap, present = os.LookupEnv("KEYMAP_POWERLINE")
-	}
-	if !present {
-		keymap = "ouch"
+		keymap, _ = os.LookupEnv("KEYMAP_POWERLINE")
 	}
 	if keymap == "main" {
-		p.appendSegment("keymap", segment{
-			content:    " I ",
-			foreground: p.theme.RepoDirtyFg,
-			background: p.theme.RepoDirtyBg,
-		})
+		p.appendSegment("keymap", editSegment)
 	}
 	if keymap == "vicmd" {
-		p.appendSegment("keymap", segment{
-			content:    " C ",
-			foreground: p.theme.RepoCleanFg,
-			background: p.theme.RepoCleanBg,
-		})
+		p.appendSegment("keymap", commandSegment)
 	}
 
 }


### PR DESCRIPTION
This is useful for people who are using vi input mode.

fixes #14 

Disadvantage is that there is a zsh snippet that is required for this to work.

Didn't try on other shells (I'm using only zsh).

I'm happy to keep it only in my own branch if there is no demand for this functionality from other users. Would be nice if this project supported some kind of plugin architecture.