### PR TITLE
Update README.md to suggest fallback bash form.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Add the following to your `.bashrc` (or `.profile` on Mac):
 
 ```
 function _update_ps1() {
-    PS1="$(~/go/bin/powerline-go -error $?)"
+    if [ -e ~/go/bin/powerline-go ]; then
+        PS1="$(~/go/bin/powerline-go -error $?)"
+    fi
 }
 
 if [ "$TERM" != "linux" ]; then

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Add the following to your `.bashrc` (or `.profile` on Mac):
 
 ```
 function _update_ps1() {
-    if [ -e ~/go/bin/powerline-go ]; then
-        PS1="$(~/go/bin/powerline-go -error $?)"
+    if [ -e $GOPATH/bin/powerline-go ]; then
+        PS1="$($GOPATH/bin/powerline-go -error $?)"
     fi
 }
 


### PR DESCRIPTION
Just a minor adjustment in using bash, to avoid issues if `powerline-go` disappears for some reason, in which case the shells default back to the 'bare' bash form.

A similar situation likely exists for the other shells, but I'm not familiar with them.