### PR TITLE
use DOCKER_HOST if present

### DIFF
--- a/segment-docker.go
+++ b/segment-docker.go
@@ -2,14 +2,27 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 )
 
 func segmentDocker(p *powerline) {
+	var docker string
 	dockerMachineName, _ := os.LookupEnv("DOCKER_MACHINE_NAME")
+	dockerHost, _ := os.LookupEnv("DOCKER_HOST")
+
 	if dockerMachineName != "" {
+		docker = dockerMachineName
+	} else if dockerHost != " " {
+		u, err := url.Parse(dockerHost)
+		if err == nil {
+			docker = u.Host
+		}
+	}
+
+	if docker != "" {
 		p.appendSegment("docker", segment{
-			content:    fmt.Sprintf(" %s ", dockerMachineName),
+			content:    fmt.Sprintf(" %s ", docker),
 			foreground: p.theme.DockerMachineFg,
 			background: p.theme.DockerMachineBg,
 		})


### PR DESCRIPTION
this adds support for displaying the host (or host:port) part of `DOCKER_HOST` if present, and `DOCKER_MACHINE_NAME` isn't set, e.g. when targeting a remote docker instance