### PR TITLE
add dotenv module

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -92,6 +92,9 @@ var themes = map[string]Theme{
 		DockerMachineFg: 177, // light purple
 		DockerMachineBg: 55,  // purple
 
+		DotEnvFg: 15, // white
+		DotEnvBg: 55, // purple
+
 		RepoCleanFg: 0,   // black
 		RepoCleanBg: 148, // a light green color
 		RepoDirtyFg: 15,  // white
@@ -415,6 +418,9 @@ var themes = map[string]Theme{
 
 		DockerMachineFg: 55,  // purple
 		DockerMachineBg: 177, // light purple
+
+		DotEnvFg: 15, // white
+		DotEnvBg: 55, // purple
 
 		RepoCleanFg: 232, // black
 		RepoCleanBg: 230, // light yellow

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func getValidCwd() string {
 var modules = map[string](func(*powerline)){
 	"cwd":      segmentCwd,
 	"docker":   segmentDocker,
+	"dotenv":   segmentDotEnv,
 	"exit":     segmentExitCode,
 	"git":      segmentGit,
 	"gitlite":  segmentGitLite,
@@ -126,7 +127,7 @@ func main() {
 		Modules: flag.String("modules",
 			"venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root",
 			"The list of modules to load, separated by ','\n"+
-				"    	(valid choices: cwd, docker, exit, git, gitlite, hg, host, jobs, perlbrew, perms, root, ssh, time, user, venv)\n"+
+				"    	(valid choices: cwd, docker, dotenv, exit, git, gitlite, hg, host, jobs, perlbrew, perms, root, ssh, time, user, venv)\n"+
 				"       "),
 		Priority: flag.String("priority",
 			"root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit",

--- a/segment-dotenv.go
+++ b/segment-dotenv.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"os"
+)
+
+func segmentDotEnv(p *powerline) {
+	stat, err := os.Stat(".env")
+	if err == nil && !stat.IsDir() {
+		p.appendSegment("dotenv", segment{
+			content:    " \u2235 ",
+			foreground: p.theme.DockerMachineFg,
+			background: p.theme.DockerMachineBg,
+		})
+	}
+}

--- a/themes.go
+++ b/themes.go
@@ -45,6 +45,9 @@ type Theme struct {
 	DockerMachineFg uint8
 	DockerMachineBg uint8
 
+	DotEnvFg uint8
+	DotEnvBg uint8
+
 	RepoCleanFg uint8
 	RepoCleanBg uint8
 	RepoDirtyFg uint8

--- a/themes/default.json
+++ b/themes/default.json
@@ -18,6 +18,8 @@
     "SshBg": 166,
     "DockerMachineFg": 177,
     "DockerMachineBg": 55,
+    "DotEnvFg": 15,
+    "DotEnvBg": 55,
     "RepoCleanFg": 0,
     "RepoCleanBg": 148,
     "RepoDirtyFg": 15,


### PR DESCRIPTION
This adds a module that shows the "therefore" symbol (∵), when a `.env` file is present in the current dir. When a tool like [direnv](http://direnv.net/) is used `.env` will set environment variables from that file, so it is good to know that the file is present.