### PR TITLE
add load module

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Usage of powerline-go:
     	 (default "patched")
   -modules string
     	 The list of modules to load, separated by ','
-    	 (valid choices: aws, cwd, docker, dotenv, exit, git, gitlite, hg, host, jobs, perlbrew, perms, root, shell-var, ssh, time, user, venv, node)
+    	 (valid choices: aws, cwd, docker, dotenv, exit, git, gitlite, hg, host, jobs, load, perlbrew, perms, root, shell-var, ssh, time, user, venv, node)
     	 (default "venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root")
   -newline
     	 Show the prompt on a new line
@@ -167,7 +167,7 @@ Usage of powerline-go:
     	 Use '~' for your home dir. You may need to escape this character to avoid shell substitution.
   -priority string
     	 Segments sorted by priority, if not enough space exists, the least priorized segments are removed first. Separate with ','
-    	 (valid choices: aws, cwd, cwd-path, docker, exit, git-branch, git-status, hg, host, jobs, perlbrew, perms, root, ssh, time, user, venv, node)
+    	 (valid choices: aws, cwd, cwd-path, docker, exit, git-branch, git-status, hg, host, jobs, load, perlbrew, perms, root, ssh, time, user, venv, node)
     	 (default "root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit,cwd-path")
   -shell string
     	 Set this to your shell type

--- a/defaults.go
+++ b/defaults.go
@@ -155,6 +155,12 @@ var themes = map[string]Theme{
 		NodeFg: 15,
 		NodeBg: 40,
 
+		LoadFg:           15,
+		LoadBg:           22,
+		LoadHighBg:       161,
+		LoadAvgValue:     5,
+		LoadThresholdBad: 1.0,
+
 		HostnameColorizedFgMap: map[uint8]uint8{
 			0:   250,
 			1:   250,
@@ -491,6 +497,12 @@ var themes = map[string]Theme{
 
 		TimeFg: 236,
 		TimeBg: 15,
+
+		LoadFg:           15,
+		LoadBg:           22,
+		LoadHighBg:       161,
+		LoadAvgValue:     5,
+		LoadThresholdBad: 1.0,
 
 		HostnameColorizedFgMap: map[uint8]uint8{
 			0:   250,

--- a/main.go
+++ b/main.go
@@ -100,6 +100,7 @@ var modules = map[string](func(*powerline)){
 	"host":      segmentHost,
 	"jobs":      segmentJobs,
 	"kube":      segmentKube,
+	"load":      segmentLoad,
 	"newline":   segmentNewline,
 	"perlbrew":  segmentPerlbrew,
 	"perms":     segmentPerms,
@@ -168,12 +169,12 @@ func main() {
 			"modules",
 			"venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root,vgo",
 			commentsWithDefaults("The list of modules to load, separated by ','",
-				"(valid choices: aws, cwd, docker, dotenv, exit, git, gitlite, hg, host, jobs, perlbrew, perms, root, shell-var, ssh, termtitle, time, user, venv, vgo)")),
+				"(valid choices: aws, cwd, docker, dotenv, exit, git, gitlite, hg, host, jobs, load, perlbrew, perms, root, shell-var, ssh, termtitle, time, user, venv, vgo)")),
 		Priority: flag.String(
 			"priority",
 			"root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit,cwd-path",
 			commentsWithDefaults("Segments sorted by priority, if not enough space exists, the least priorized segments are removed first. Separate with ','",
-				"(valid choices: aws, cwd, cwd-path, docker, exit, git-branch, git-status, hg, host, jobs, perlbrew, perms, root, ssh, time, user, venv, vgo)")),
+				"(valid choices: aws, cwd, cwd-path, docker, exit, git-branch, git-status, hg, host, jobs, load, perlbrew, perms, root, ssh, time, user, venv, vgo)")),
 		MaxWidthPercentage: flag.Int(
 			"max-width",
 			0,

--- a/segment-load.go
+++ b/segment-load.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/shirou/gopsutil/load"
+)
+
+func segmentLoad(p *powerline) {
+	c := runtime.NumCPU()
+	a, err := load.Avg()
+	if err != nil {
+		return
+	}
+	bg := p.theme.LoadBg
+
+	load := a.Load5
+	switch p.theme.LoadAvgValue {
+	case 1:
+		load = a.Load1
+	case 15:
+		load = a.Load15
+	}
+
+	if load > float64(c)*p.theme.LoadThresholdBad {
+		bg = p.theme.LoadHighBg
+	}
+
+	p.appendSegment("load", segment{
+		content:    fmt.Sprintf("%.2f", a.Load5),
+		foreground: p.theme.LoadFg,
+		background: bg,
+	})
+}

--- a/themes.go
+++ b/themes.go
@@ -105,4 +105,10 @@ type Theme struct {
 
 	NodeFg uint8
 	NodeBg uint8
+
+	LoadFg           uint8
+	LoadBg           uint8
+	LoadHighBg       uint8
+	LoadAvgValue     byte
+	LoadThresholdBad float64
 }

--- a/themes/default.json
+++ b/themes/default.json
@@ -56,6 +56,11 @@
   "ShellVarBg": 11,
   "NodeFg": 15,
   "NodeBg": 40,
+  "LoadFg": 15,
+  "LoadBg": 22,
+  "LoadHighBg": 161,
+  "LoadAvgValue":     5,
+  "LoadThresholdBad": 1.0,
   "HostnameColorizedFgMap": {
     "0": 250,
     "1": 250,


### PR DESCRIPTION
Adds the current load (5 minutes average) as new segment.
If the load is less than the numbers of CPU cores, the background
is normal, if it is higher, the high background color is used.