### PR TITLE
Add support for newline segment

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ var modules = map[string](func(*powerline)){
 	"host":     segmentHost,
 	"jobs":     segmentJobs,
 	"kube":     segmentKube,
+	"newline":  segmentNewline,
 	"perlbrew": segmentPerlbrew,
 	"perms":    segmentPerms,
 	"root":     segmentRoot,

--- a/segment-newline.go
+++ b/segment-newline.go
@@ -1,0 +1,5 @@
+package main
+
+func segmentNewline(p *powerline) {
+	p.newRow()
+}


### PR DESCRIPTION
Adds the ability to define a "newline" segment to the prompt, which simply wrap the prompt around onto the following line. This allows the user to make multi-line shell prompts.

In order to add this functionality, I had to refactor some of the powerline.Draw() code as well. There were other ways to do this, but this seemed like the most straightforward way.

This is my first time writing any go code, and I'm more than receptive to any feedback you might have. Thanks!