### PR TITLE
Added module shell-var that displays a specified shell variable, implements #51

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -141,6 +141,9 @@ var themes = map[string]Theme{
 		TimeFg: 15,
 		TimeBg: 236,
 
+		ShellVarFg: 52,
+		ShellVarBg: 11,
+
 		HostnameColorizedFgMap: map[uint8]uint8{
 			0:   250,
 			1:   250,

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ type segment struct {
 	separatorForeground uint8
 	priority            int
 	width               int
+	special             bool
 }
 
 type args struct {
@@ -44,6 +45,7 @@ type args struct {
 	PrevError            *int
 	IgnoreRepos          *string
 	ShortenGKENames      *bool
+	ShellVar             *string
 }
 
 func (s segment) computeWidth() int {
@@ -102,6 +104,7 @@ var modules = map[string](func(*powerline)){
 	"time":     segmentTime,
 	"user":     segmentUser,
 	"venv":     segmentVirtualEnv,
+	"shell-var": segmentShellVar,
 }
 
 func comments(lines ...string) string {
@@ -185,6 +188,10 @@ func main() {
 			"shorten-gke-names",
 			false,
 			comments("Shortens names for GKE Kube clusters.")),
+		ShellVar: flag.String(
+			"shell-var",
+			"",
+			comments("A shell variable to add to the segments.")),
 	}
 	flag.Parse()
 	if strings.HasSuffix(*args.Theme, ".json") {

--- a/segment-shellvar.go
+++ b/segment-shellvar.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+)
+
+func segmentShellVar(p *powerline) {
+	var varContent string
+	var varExists bool
+	varContent, varExists = os.LookupEnv(*p.args.ShellVar);
+
+	if (varExists) {
+		p.appendSegment("shell-var", segment {
+			content: "\\$" + *p.args.ShellVar + ":" + varContent,
+			foreground: p.theme.ShellVarFg,
+			background: p.theme.ShellVarBg,
+		})
+	}
+}

--- a/themes.go
+++ b/themes.go
@@ -93,4 +93,7 @@ type Theme struct {
 
 	TimeFg uint8
 	TimeBg uint8
+
+	ShellVarFg uint8
+	ShellVarBg uint8
 }


### PR DESCRIPTION
Added a new command line parameter _shell-var_ to indicate the name of a shell variable to display:

`powerline-go -modules "user,cwd,root,shell-var" -shell-var SHELL`
![shell-var](https://user-images.githubusercontent.com/2236848/34077992-ae7adb9e-e2d6-11e7-87f6-5a95adf5adba.png)
