### PR TITLE
Remember to append segments if CwdMode is dironly

### DIFF
--- a/segment-cwd.go
+++ b/segment-cwd.go
@@ -185,29 +185,29 @@ func segmentCwd(p *powerline) {
 				})
 				pathSegments = append(pathSegments, secondPart...)
 			}
+		}
 
-			for idx, pathSegment := range pathSegments {
-				isLastDir := idx == len(pathSegments)-1
-				foreground, background := getColor(p, pathSegment, isLastDir)
+		for idx, pathSegment := range pathSegments {
+			isLastDir := idx == len(pathSegments)-1
+			foreground, background := getColor(p, pathSegment, isLastDir)
 
-				segment := segment{
-					content:    escapeVariables(p, maybeShortenName(p, pathSegment.path)),
-					foreground: foreground,
-					background: background,
-				}
-
-				if !(pathSegment.home && p.theme.HomeSpecialDisplay) && !isLastDir {
-					segment.separator = p.symbolTemplates.SeparatorThin
-					segment.separatorForeground = p.theme.SeparatorFg
-				}
-
-				origin := "cwd-path"
-				if isLastDir {
-					origin = "cwd"
-				}
-
-				p.appendSegment(origin, segment)
+			segment := segment{
+				content:    escapeVariables(p, maybeShortenName(p, pathSegment.path)),
+				foreground: foreground,
+				background: background,
 			}
+
+			if !(pathSegment.home && p.theme.HomeSpecialDisplay) && !isLastDir {
+				segment.separator = p.symbolTemplates.SeparatorThin
+				segment.separatorForeground = p.theme.SeparatorFg
+			}
+
+			origin := "cwd-path"
+			if isLastDir {
+				origin = "cwd"
+			}
+
+			p.appendSegment(origin, segment)
 		}
 	}
 }


### PR DESCRIPTION
Hey, thanks for the great project! It's much zippier than the python version.

Powerline fails to append the segment when in `dironly` mode, as the `pathSegment` is sliced but never used. This is a minimal fix to make it work. Let me know if you want any changes. 😊