### PR TITLE
Issue #11 - Exit codes either meaningful or numeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ported to golang by @justjanne.
 - Shows the current Python [virtualenv](http://www.virtualenv.org/) environment
 - It's easy to customize and extend. See below for details.
 
-**Table of Contents** 
+**Table of Contents**
 
 - [Version Control](#version-control)
 - [Installation](#installation)
@@ -143,6 +143,8 @@ Usage of powerline-go:
     	 Use East Asian Ambiguous Widths
   -error int
     	 Exit code of previously executed command
+  --numeric-exit-codes
+    	 Print the exit code of previously command in numeric value
   -ignore-repos string
     	 A list of git repos to ignore. Separate with ','
     	 Repos are identified by their root directory.

--- a/main.go
+++ b/main.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/mattn/go-runewidth"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	runewidth "github.com/mattn/go-runewidth"
 )
 
 const (
@@ -42,6 +43,7 @@ type args struct {
 	MaxWidthPercentage   *int
 	TruncateSegmentWidth *int
 	PrevError            *int
+	NumericExitCodes     *bool
 	IgnoreRepos          *string
 	ShortenGKENames      *bool
 	ShellVar             *string
@@ -178,6 +180,10 @@ func main() {
 			"error",
 			0,
 			comments("Exit code of previously executed command")),
+		NumericExitCodes: flag.Bool(
+			"numeric-exit-codes",
+			false,
+			comments("Shows numeric exit codes for errors.")),
 		IgnoreRepos: flag.String(
 			"ignore-repos",
 			"",

--- a/segment-exitcode.go
+++ b/segment-exitcode.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 )
 
 func getMeaningFromExitCode(exitCode int) string {
@@ -64,8 +65,13 @@ func getMeaningFromExitCode(exitCode int) string {
 }
 
 func segmentExitCode(p *powerline) {
+	var meaning string
 	if *p.args.PrevError != 0 {
-		meaning := getMeaningFromExitCode(*p.args.PrevError)
+		if *p.args.NumericExitCodes {
+			meaning = strconv.Itoa(*p.args.PrevError)
+		} else {
+			meaning = getMeaningFromExitCode(*p.args.PrevError)
+		}
 		p.appendSegment("exit", segment{
 			content:    meaning,
 			foreground: p.theme.CmdFailedFg,


### PR DESCRIPTION
Exit codes are printed using an meaningful name by default (eg. `ERROR` for exit code 1 etc.). With this addition, the flag`-numeric-exit-codes` can be included to print exit codes using a numeric value.

#11 
