### PR TITLE
Add support for nix-shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Ported to golang by @justjanne.
 - Changes color if the last command exited with a failure code
 - If you're too deep into a directory tree, shortens the displayed path with an ellipsis
 - Shows the current Python [virtualenv](http://www.virtualenv.org/) environment
+- Shows if you are in a [nix](https://nixos.org.org/) shell
 - It's easy to customize and extend. See below for details.
 
 **Table of Contents**
@@ -154,7 +155,7 @@ Usage of powerline-go:
     	 (default "patched")
   -modules string
     	 The list of modules to load, separated by ','
-    	 (valid choices: aws, cwd, docker, dotenv, exit, git, gitlite, hg, host, jobs, load, perlbrew, perms, root, shell-var, ssh, time, user, venv, node)
+    	 (valid choices: aws, cwd, docker, dotenv, exit, git, gitlite, hg, host, jobs, load, nix-shell, perlbrew, perms, root, shell-var, ssh, time, user, venv, node)
     	 (default "venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root")
   -newline
     	 Show the prompt on a new line
@@ -167,7 +168,7 @@ Usage of powerline-go:
     	 Use '~' for your home dir. You may need to escape this character to avoid shell substitution.
   -priority string
     	 Segments sorted by priority, if not enough space exists, the least priorized segments are removed first. Separate with ','
-    	 (valid choices: aws, cwd, cwd-path, docker, exit, git-branch, git-status, hg, host, jobs, load, perlbrew, perms, root, ssh, time, user, venv, node)
+    	 (valid choices: aws, cwd, cwd-path, docker, exit, git-branch, git-status, hg, host, jobs, load, nix-shell, perlbrew, perms, root, ssh, time, user, venv, node)
     	 (default "root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit,cwd-path")
   -shell string
     	 Set this to your shell type

--- a/defaults.go
+++ b/defaults.go
@@ -161,6 +161,9 @@ var themes = map[string]Theme{
 		LoadAvgValue:     5,
 		LoadThresholdBad: 1.0,
 
+		NixShellFg: 00,
+		NixShellBg: 69, // a light blue
+
 		HostnameColorizedFgMap: map[uint8]uint8{
 			0:   250,
 			1:   250,
@@ -503,6 +506,9 @@ var themes = map[string]Theme{
 		LoadHighBg:       161,
 		LoadAvgValue:     5,
 		LoadThresholdBad: 1.0,
+
+		NixShellFg: 69, // a light blue
+		NixShellBg: 254,
 
 		HostnameColorizedFgMap: map[uint8]uint8{
 			0:   250,

--- a/main.go
+++ b/main.go
@@ -113,6 +113,7 @@ var modules = map[string](func(*powerline)){
 	"user":      segmentUser,
 	"venv":      segmentVirtualEnv,
 	"vgo":       segmentVirtualGo,
+	"nix-shell": segmentNixShell,
 }
 
 func comments(lines ...string) string {
@@ -167,14 +168,14 @@ func main() {
 				"(valid choices: bare, bash, zsh)")),
 		Modules: flag.String(
 			"modules",
-			"venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root,vgo",
+			"nix-shell,venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root,vgo",
 			commentsWithDefaults("The list of modules to load, separated by ','",
-				"(valid choices: aws, cwd, docker, dotenv, exit, git, gitlite, hg, host, jobs, load, perlbrew, perms, root, shell-var, ssh, termtitle, time, user, venv, vgo)")),
+				"(valid choices: aws, cwd, docker, dotenv, exit, git, gitlite, hg, host, jobs, load, nix-shell, perlbrew, perms, root, shell-var, ssh, termtitle, time, user, venv, vgo)")),
 		Priority: flag.String(
 			"priority",
 			"root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit,cwd-path",
 			commentsWithDefaults("Segments sorted by priority, if not enough space exists, the least priorized segments are removed first. Separate with ','",
-				"(valid choices: aws, cwd, cwd-path, docker, exit, git-branch, git-status, hg, host, jobs, load, perlbrew, perms, root, ssh, time, user, venv, vgo)")),
+				"(valid choices: aws, cwd, cwd-path, docker, exit, git-branch, git-status, hg, host, jobs, load, nix-shell, perlbrew, perms, root, ssh, time, user, venv, vgo)")),
 		MaxWidthPercentage: flag.Int(
 			"max-width",
 			0,

--- a/segment-nix-shell.go
+++ b/segment-nix-shell.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+)
+
+func segmentNixShell(p *powerline) {
+	var nixShell string
+		nixShell, _ = os.LookupEnv("IN_NIX_SHELL")
+	if nixShell == "" {
+		return
+	} else {
+		p.appendSegment("nix-shell", segment{
+			content:    nixShell,
+			foreground: p.theme.NixShellFg,
+			background: p.theme.NixShellBg,
+		})
+	}
+}

--- a/themes.go
+++ b/themes.go
@@ -111,4 +111,7 @@ type Theme struct {
 	LoadHighBg       uint8
 	LoadAvgValue     byte
 	LoadThresholdBad float64
+
+	NixShellFg uint8
+	NixShellBg uint8
 }

--- a/themes/default.json
+++ b/themes/default.json
@@ -61,6 +61,8 @@
   "LoadHighBg": 161,
   "LoadAvgValue":     5,
   "LoadThresholdBad": 1.0,
+  "NixShellFg": 0,
+  "NixShellBg": 69,
   "HostnameColorizedFgMap": {
     "0": 250,
     "1": 250,


### PR DESCRIPTION
Add support for [nix](https://nixos.org)-shell

To do:
  * [x] choose a color for the segment (maybe light blue like in the [logo](https://nixos.org)?)
  * [x] maybe put it in the default segments since it's so cheap to check and only uses space if actually using it