### PR TITLE
Allow .envrc for dotenv segment

### DIFF
--- a/segment-dotenv.go
+++ b/segment-dotenv.go
@@ -5,8 +5,16 @@ import (
 )
 
 func segmentDotEnv(p *powerline) {
-	stat, err := os.Stat(".env")
-	if err == nil && !stat.IsDir() {
+	files := []string{".env", ".envrc"}
+	dotEnv := false
+	for _, file := range files {
+		stat, err := os.Stat(file)
+		if err == nil && !stat.IsDir() {
+			dotEnv = true
+			break
+		}
+	}
+	if dotEnv {
 		p.appendSegment("dotenv", segment{
 			content:    "\u2235",
 			foreground: p.theme.DotEnvFg,


### PR DESCRIPTION
[direnv] uses `.envrc` as filename.

[direnv]: https://github.com/direnv/direnv