### PR TITLE
make gitlite lighter by implementing it in Go

### DIFF
--- a/powerline.go
+++ b/powerline.go
@@ -3,13 +3,15 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"strings"
+
+	"os"
+	"strconv"
 
 	"github.com/mattn/go-runewidth"
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/text/width"
-	"os"
-	"strconv"
 )
 
 type ShellInfo struct {
@@ -48,7 +50,7 @@ func NewPowerline(args args, cwd string, priorities map[string]int) *powerline {
 		if r == "" {
 			continue
 		}
-		p.ignoreRepos[r] = true
+		p.ignoreRepos[filepath.Clean(r)] = true
 	}
 	p.pathAliases = make(map[string]string)
 	for _, pa := range strings.Split(*args.PathAliases, ",") {

--- a/segment-gitlite.go
+++ b/segment-gitlite.go
@@ -1,37 +1,78 @@
 package main
 
 import (
-	"strings"
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 )
 
-func segmentGitLite(p *powerline) {
-	if len(p.ignoreRepos) > 0 {
-		out, err := runGitCommand("git", "rev-parse", "--show-toplevel")
-		if err != nil {
-			return
+type gitNotFoundErr struct{}
+
+func (gitNotFoundErr) Error() string {
+	return ".git is not found"
+}
+
+func findRepoRoot() (repoPath string, head []byte, err error) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		return "", nil, err
+	}
+recurseUp:
+	for {
+		fi, err := os.Stat(filepath.Join(pwd, ".git"))
+		switch {
+		case err == nil:
+			if fi.IsDir() {
+				break
+			}
+			fallthrough
+		case os.IsNotExist(err):
+			if pwd == "/" {
+				return "", nil, gitNotFoundErr{}
+			}
+			pwd = filepath.Join(pwd, "..")
+			continue recurseUp
+		default:
+			return "", nil, err
 		}
-		out = strings.TrimSpace(out)
-		if p.ignoreRepos[out] {
-			return
-		}
+		head, err := ioutil.ReadFile(filepath.Join(pwd, ".git", "HEAD"))
+		return pwd, head, err
+	}
+}
+
+var refPrefix = []byte("ref:")
+
+const shortHashLen = 10
+
+func headToOutput(head []byte) string {
+	if bytes.HasPrefix(head, refPrefix) {
+		// It's a ref, so return branch name.
+		// Example: refs: refs/heads/master
+		ref := bytes.TrimSpace(head[len(refPrefix):])
+		ref = ref[bytes.LastIndexByte(ref, '/')+1:]
+		return string(ref)
 	}
 
-	out, err := runGitCommand("git", "rev-parse", "--abbrev-ref", "HEAD")
+	// Treat it as a git hash. Return first 10 chars.
+	hash := bytes.TrimSpace(head)
+	if len(hash) < shortHashLen {
+		return string(hash)
+	}
+	return string(hash[:shortHashLen])
+}
+
+func segmentGitLite(p *powerline) {
+	repoRoot, head, err := findRepoRoot()
 	if err != nil {
 		return
 	}
-
-	status := strings.TrimSpace(out)
-	var branch string
-
-	if status != "HEAD" {
-		branch = status
-	} else {
-		branch = getGitDetachedBranch(p)
+	if p.ignoreRepos[repoRoot] {
+		return
 	}
 
 	p.appendSegment("git-branch", segment{
-		content:    branch,
+		content:    headToOutput(head),
 		foreground: p.theme.RepoCleanFg,
 		background: p.theme.RepoCleanBg,
 	})


### PR DESCRIPTION
Thanks for the awesome project! This PR implements the gitlite segment in Go by looking at `.git/HEAD` directly. A one-off test for the linux repo shows a decent speedup:

```bash
$ time bash -c 'for i in $(seq 1 100); do ~/gopath/src/github.com/justjanne/powerline-go/powerline-go.master -modules=gitlite; done > /dev/null'
bash -c   0.46s user 0.79s system 77% cpu 1.609 total
```

```bash
$ time bash -c 'for i in $(seq 1 100); do ~/gopath/src/github.com/justjanne/powerline-go/powerline-go -modules=gitlite; done > /dev/null'
bash -c   0.13s user 0.27s system 69% cpu 0.567 total
```