### PR TITLE
Suggest safer defaults for Bash install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ Add the following to your `.bashrc` (or `.profile` on Mac):
 
 ```
 function _update_ps1() {
-    PS1="$(~/go/bin/powerline-go -error $?)"
+    PS1="$($GOPATH/bin/powerline-go -error $?)"
 }
 
-if [ "$TERM" != "linux" ]; then
+if [ "$TERM" != "linux" ] && [ -f "$GOPATH/bin/powerline-go" ]; then
     PROMPT_COMMAND="_update_ps1; $PROMPT_COMMAND"
 fi
 ```
@@ -234,10 +234,10 @@ function _update_ps1() {
     rm -f "$INTERACTIVE_BASHPID_TIMER"
   fi
 
-  PS1="$(powerline-go -modules duration -duration $__DURATION -error $__ERRCODE -shell bash)"
+  PS1="$($GOPATH/bin/powerline-go -modules duration -duration $__DURATION -error $__ERRCODE -shell bash)"
 }
 
-if [ "$TERM" != "linux" ]; then
+if [ "$TERM" != "linux" ] && [ -f "$GOPATH/bin/powerline-go" ]; then
   PROMPT_COMMAND="_update_ps1; $PROMPT_COMMAND"
 fi
 ```


### PR DESCRIPTION
This commit makes two small Bash configuration changes to the README:

* Ensure `powerline-go` is actually present in the user's `$GOPATH` before trying to change the shell prompt
  * Helps prevent accidentally breaking the shell like I did (thus my commit, jwflory/conf@bd21d487e69d5cf1decdcc5deeb6b901f865d8a0)
* Use `$GOPATH` for executing the binary (I believe it's better practice to use `$GOPATH` instead of hard-coding it in the bashrc – this way, Bash will always look wherever the user has configured their `$GOPATH` to be)