### PR TITLE
Ignore git submodules when using git segment

### DIFF
--- a/segment-git.go
+++ b/segment-git.go
@@ -137,7 +137,7 @@ func segmentGit(p *powerline) {
 		}
 	}
 
-	out, err := runGitCommand("git", "status", "--porcelain", "-b")
+	out, err := runGitCommand("git", "status", "--porcelain", "-b", "--ignore-submodules")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
In very large repos with multiple git submodules `git status` can take
quite a long time.  The information about submodules is not used in the
prompt as it is.  This commit ignores submodules when calling `git
status`.

Addresses https://github.com/justjanne/powerline-go/issues/104.