### PR TITLE
Fix incorrect duration

### DIFF
--- a/segment-duration.go
+++ b/segment-duration.go
@@ -35,10 +35,6 @@ func segmentDuration(p *powerline) {
 
 	durationValue := strings.Trim(*p.args.Duration, "'\"")
 
-	// Arguments may come in two forms, "int" and "float".  An int represents
-	// just whole seconds, while a float is the number of seconds and fractions
-	// of a second.
-
 	hasPrecision := strings.Index(durationValue, ".") != -1
 
 	d, err := time.ParseDuration(durationValue + "s")
@@ -51,52 +47,40 @@ func segmentDuration(p *powerline) {
 		return
 	}
 
-	var content string
-	if hasPrecision {
+	if d > 0 {
+		var content string
 		ns := d.Nanoseconds()
 		if ns > hours {
 			hrs := ns / hours
 			ns -= hrs * hours
 			mins := ns / minutes
-			content = fmt.Sprintf("%dh, %dm", hrs, mins)
+			content = fmt.Sprintf("%dh %dm", hrs, mins)
 		} else if ns > minutes {
 			mins := ns / minutes
 			ns -= mins * minutes
 			secs := ns / seconds
-			content = fmt.Sprintf("%dm, %ds", mins, secs)
+			content = fmt.Sprintf("%dm %ds", mins, secs)
+		} else if !hasPrecision {
+			secs := ns / seconds
+			content = fmt.Sprintf("%ds", secs)
 		} else if ns > seconds {
 			secs := ns / seconds
 			ns -= secs * seconds
 			millis := ns / milliseconds
-			content = fmt.Sprintf("%ds, %dms", secs, millis)
+			content = fmt.Sprintf("%ds %dms", secs, millis)
 		} else if ns > milliseconds {
 			millis := ns / milliseconds
 			ns -= millis * milliseconds
 			micros := ns / microseconds
-			content = fmt.Sprintf("%dms, %d\u00B5s", millis, micros)
+			content = fmt.Sprintf("%dms %d\u00B5s", millis, micros)
 		} else {
 			content = fmt.Sprintf("%d\u00B5s", ns/microseconds)
 		}
-	} else {
-		s := int64(d.Seconds())
-		if s > hours {
-			hrs := s / hours
-			s -= hrs * hours
-			mins := s / minutes
-			content = fmt.Sprintf("%dh, %dm", hrs, mins)
-		} else if s > minutes {
-			mins := s / minutes
-			s -= mins * minutes
-			secs := s / seconds
-			content = fmt.Sprintf("%dm, %ds", mins, secs)
-		} else {
-			content = fmt.Sprintf("%ds", s)
-		}
-	}
 
-	p.appendSegment("duration", segment{
-		content:    content,
-		foreground: p.theme.DurationFg,
-		background: p.theme.DurationBg,
-	})
+		p.appendSegment("duration", segment{
+			content:    content,
+			foreground: p.theme.DurationFg,
+			background: p.theme.DurationBg,
+		})
+	}
 }


### PR DESCRIPTION
* When duration is an integer, the calculation to display the duration
string is false because it use the wrong units: duration use seconds as
unit while hours,minutes,seconds constants are in nanoseconds