### PR TITLE
Accumulate all readable configs

### DIFF
--- a/segment-kube.go
+++ b/segment-kube.go
@@ -55,8 +55,12 @@ func segmentKube(p *powerline) {
 	paths := append(strings.Split(os.Getenv("KUBECONFIG"), ":"), path.Join(homePath(), ".kube", "config"))
 	config := &KubeConfig{}
 	for _, configPath := range paths {
-		if readKubeConfig(config, configPath) == nil {
-			break
+		temp := &KubeConfig{}
+		if readKubeConfig(temp, configPath) == nil {
+			config.Contexts = append(config.Contexts, temp.Contexts...)
+			if config.CurrentContext == "" {
+				config.CurrentContext = temp.CurrentContext
+			}
 		}
 	}
 


### PR DESCRIPTION
I have split my kube config in separate files and without this change the kube segment disappears if I switch to a context not in the main file.