### PR TITLE
Add `-shorten-eks-names` command-line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Usage of powerline-go:
     	 A shell variable to add to the segments.
   -shorten-gke-names
     	 Shortens names for GKE Kube clusters.
+  -shorten-eks-names
+    	 Shortens names for EKS Kube clusters.
   -theme string
     	 Set this to the theme you want to use
     	 (valid choices: default, low-contrast)

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ type args struct {
 	NumericExitCodes     *bool
 	IgnoreRepos          *string
 	ShortenGKENames      *bool
+	ShortenEKSNames      *bool
 	ShellVar             *string
 	PathAliases          *string
 	Duration             *string
@@ -222,6 +223,10 @@ func main() {
 			"shorten-gke-names",
 			false,
 			comments("Shortens names for GKE Kube clusters.")),
+		ShortenEKSNames: flag.Bool(
+			"shorten-eks-names",
+			false,
+			comments("Shortens names for EKS Kube clusters.")),
 		ShellVar: flag.String(
 			"shell-var",
 			"",

--- a/segment-kube.go
+++ b/segment-kube.go
@@ -5,10 +5,12 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
 	"fmt"
+
 	"gopkg.in/yaml.v2"
 )
 
@@ -82,6 +84,15 @@ func segmentKube(p *powerline) {
 		if len(segments) > 3 {
 			cluster = strings.Join(segments[3:], "_")
 		}
+	}
+
+	// With AWS EKS, cluster names are ARNs; it makes more sense to shorten them
+	// so "eks-infra" instead of "arn:aws:eks:us-east-1:XXXXXXXXXXXX:cluster/eks-infra
+	const arnRegexString string = "^arn:aws:eks:[[:alnum:]-]+:[[:digit:]]+:cluster/(.*)$"
+	arnRe := regexp.MustCompile(arnRegexString)
+
+	if arnMatches := arnRe.FindStringSubmatch(cluster); arnMatches != nil && *p.args.ShortenEKSNames {
+		cluster = arnMatches[1]
 	}
 
 	// Only draw the icon once


### PR DESCRIPTION
Similar to `-shorten-gke-names`, optionally shorten cluster names that
are specified as EKS ARNs