### PR TITLE
feat: add support for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ powerline-go
 .glide/
 
 /.idea/
+~

--- a/defaults.go
+++ b/defaults.go
@@ -81,6 +81,9 @@ var themes = map[string]Theme{
 	"default": {
 		Reset: 0xFF,
 
+		DefaultFg: 250,
+		DefaultBg: 240,
+
 		UsernameFg:     250,
 		UsernameBg:     240,
 		UsernameRootBg: 124,
@@ -444,6 +447,9 @@ var themes = map[string]Theme{
 	"low-contrast": {
 		Reset: 0xFF,
 
+		DefaultFg: 234,
+		DefaultBg: 250,
+
 		UsernameFg:     234,
 		UsernameBg:     250,
 		UsernameRootBg: 198,
@@ -791,6 +797,8 @@ var themes = map[string]Theme{
 	},
 	"solarized-dark16": {
 		Reset:              8,
+		DefaultFg:          15,
+		DefaultBg:          4,
 		UsernameFg:         15,
 		UsernameBg:         4,
 		UsernameRootBg:     1,
@@ -1115,6 +1123,8 @@ var themes = map[string]Theme{
 	},
 	"solarized-light16": {
 		Reset:              0,
+		DefaultFg:          15,
+		DefaultBg:          4,
 		UsernameFg:         15,
 		UsernameBg:         4,
 		UsernameRootBg:     1,

--- a/main.go
+++ b/main.go
@@ -7,8 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
-
-	"github.com/mattn/go-runewidth"
 )
 
 type alignment int
@@ -28,17 +26,6 @@ const (
 	// MinInteger minimum integer
 	MinInteger = ^MaxInteger
 )
-
-type segment struct {
-	content             string
-	foreground          uint8
-	background          uint8
-	separator           string
-	separatorForeground uint8
-	priority            int
-	width               int
-	hideSeparators      bool
-}
 
 type args struct {
 	CwdMode               *string
@@ -66,13 +53,6 @@ type args struct {
 	Duration              *string
 	Eval                  *bool
 	Condensed             *bool
-}
-
-func (s segment) computeWidth(condensed bool) int {
-	if condensed {
-		return runewidth.StringWidth(s.content) + runewidth.StringWidth(s.separator)
-	}
-	return runewidth.StringWidth(s.content) + runewidth.StringWidth(s.separator) + 2
 }
 
 func warn(msg string) {

--- a/powerline.go
+++ b/powerline.go
@@ -84,11 +84,13 @@ func newPowerline(args args, cwd string, priorities map[string]int, align alignm
 	}
 	for _, module := range strings.Split(mods, ",") {
 		elem, ok := modules[module]
-		if !ok {
-			println("Module not found: " + module)
-			continue
+		if ok {
+			elem(p)
+		} else {
+			if ok := segmentPlugin(p, module); !ok {
+				println("Module not found: " + module)
+			}
 		}
-		elem(p)
 	}
 	return p
 }
@@ -109,6 +111,10 @@ func (p *powerline) bgColor(code uint8) string {
 }
 
 func (p *powerline) appendSegment(origin string, segment pwl.Segment) {
+	if segment.Foreground == segment.Background && segment.Background == 0 {
+		segment.Background = p.theme.DefaultBg
+		segment.Foreground = p.theme.DefaultFg
+	}
 	if segment.Separator == "" {
 		if p.isRightPrompt() {
 			segment.Separator = p.symbolTemplates.SeparatorReverse

--- a/powerline.go
+++ b/powerline.go
@@ -3,11 +3,11 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"strings"
-
 	"os"
 	"strconv"
+	"strings"
 
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"github.com/mattn/go-runewidth"
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/text/width"
@@ -36,7 +36,7 @@ type powerline struct {
 	symbolTemplates        Symbols
 	priorities             map[string]int
 	ignoreRepos            map[string]bool
-	Segments               [][]segment
+	Segments               [][]pwl.Segment
 	curSegment             int
 	align                  alignment
 	rightPowerline         *powerline
@@ -68,7 +68,7 @@ func newPowerline(args args, cwd string, priorities map[string]int, align alignm
 		kv := strings.SplitN(pa, "=", 2)
 		p.pathAliases[kv[0]] = kv[1]
 	}
-	p.Segments = make([][]segment, 1)
+	p.Segments = make([][]pwl.Segment, 1)
 	var mods string
 	if p.align == alignLeft {
 		mods = *args.Modules
@@ -108,25 +108,25 @@ func (p *powerline) bgColor(code uint8) string {
 	return p.color("48", code)
 }
 
-func (p *powerline) appendSegment(origin string, segment segment) {
-	if segment.separator == "" {
+func (p *powerline) appendSegment(origin string, segment pwl.Segment) {
+	if segment.Separator == "" {
 		if p.isRightPrompt() {
-			segment.separator = p.symbolTemplates.SeparatorReverse
+			segment.Separator = p.symbolTemplates.SeparatorReverse
 		} else {
-			segment.separator = p.symbolTemplates.Separator
+			segment.Separator = p.symbolTemplates.Separator
 		}
 	}
-	if segment.separatorForeground == 0 {
-		segment.separatorForeground = segment.background
+	if segment.SeparatorForeground == 0 {
+		segment.SeparatorForeground = segment.Background
 	}
 	priority, _ := p.priorities[origin]
-	segment.priority += priority
-	segment.width = segment.computeWidth(*p.args.Condensed)
+	segment.Priority += priority
+	segment.Width = segment.ComputeWidth(*p.args.Condensed)
 	p.Segments[p.curSegment] = append(p.Segments[p.curSegment], segment)
 }
 
 func (p *powerline) newRow() {
-	p.Segments = append(p.Segments, make([]segment, 0))
+	p.Segments = append(p.Segments, make([]pwl.Segment, 0))
 	p.curSegment = p.curSegment + 1
 }
 
@@ -157,34 +157,34 @@ func (p *powerline) truncateRow(rowNum int) {
 
 	if shellMaxLength > 0 {
 		for _, segment := range row {
-			rowLength += segment.width
+			rowLength += segment.Width
 		}
 
 		if rowLength > shellMaxLength && *p.args.TruncateSegmentWidth > 0 {
 			minPriorityNotTruncated := MaxInteger
 			minPriorityNotTruncatedSegmentID := -1
 			for idx, segment := range row {
-				if segment.width > *p.args.TruncateSegmentWidth && segment.priority < minPriorityNotTruncated {
-					minPriorityNotTruncated = segment.priority
+				if segment.Width > *p.args.TruncateSegmentWidth && segment.Priority < minPriorityNotTruncated {
+					minPriorityNotTruncated = segment.Priority
 					minPriorityNotTruncatedSegmentID = idx
 				}
 			}
 			for minPriorityNotTruncatedSegmentID != -1 && rowLength > shellMaxLength {
 				segment := row[minPriorityNotTruncatedSegmentID]
 
-				rowLength -= segment.width
+				rowLength -= segment.Width
 
-				segment.content = runewidth.Truncate(segment.content, *p.args.TruncateSegmentWidth-runewidth.StringWidth(segment.separator)-3, "…")
-				segment.width = segment.computeWidth(*p.args.Condensed)
+				segment.Content = runewidth.Truncate(segment.Content, *p.args.TruncateSegmentWidth-runewidth.StringWidth(segment.Separator)-3, "…")
+				segment.Width = segment.ComputeWidth(*p.args.Condensed)
 
 				row = append(append(row[:minPriorityNotTruncatedSegmentID], segment), row[minPriorityNotTruncatedSegmentID+1:]...)
-				rowLength += segment.width
+				rowLength += segment.Width
 
 				minPriorityNotTruncated = MaxInteger
 				minPriorityNotTruncatedSegmentID = -1
 				for idx, segment := range row {
-					if segment.width > *p.args.TruncateSegmentWidth && segment.priority < minPriorityNotTruncated {
-						minPriorityNotTruncated = segment.priority
+					if segment.Width > *p.args.TruncateSegmentWidth && segment.Priority < minPriorityNotTruncated {
+						minPriorityNotTruncated = segment.Priority
 						minPriorityNotTruncatedSegmentID = idx
 					}
 				}
@@ -195,15 +195,15 @@ func (p *powerline) truncateRow(rowNum int) {
 			minPriority := MaxInteger
 			minPrioritySegmentID := -1
 			for idx, segment := range row {
-				if segment.priority < minPriority {
-					minPriority = segment.priority
+				if segment.Priority < minPriority {
+					minPriority = segment.Priority
 					minPrioritySegmentID = idx
 				}
 			}
 			if minPrioritySegmentID != -1 {
 				segment := row[minPrioritySegmentID]
 				row = append(row[:minPrioritySegmentID], row[minPrioritySegmentID+1:]...)
-				rowLength -= segment.width
+				rowLength -= segment.Width
 			}
 		}
 	}
@@ -238,8 +238,8 @@ func (p *powerline) drawRow(rowNum int, buffer *bytes.Buffer) {
 		buffer.WriteRune(' ')
 	}
 	for idx, segment := range row {
-		if segment.hideSeparators {
-			buffer.WriteString(segment.content)
+		if segment.HideSeparators {
+			buffer.WriteString(segment.Content)
 			continue
 		}
 		var separatorBackground string
@@ -248,38 +248,38 @@ func (p *powerline) drawRow(rowNum int, buffer *bytes.Buffer) {
 				separatorBackground = p.reset
 			} else {
 				prevSegment := row[idx-1]
-				separatorBackground = p.bgColor(prevSegment.background)
+				separatorBackground = p.bgColor(prevSegment.Background)
 			}
 			buffer.WriteString(separatorBackground)
-			buffer.WriteString(p.fgColor(segment.separatorForeground))
-			buffer.WriteString(segment.separator)
+			buffer.WriteString(p.fgColor(segment.SeparatorForeground))
+			buffer.WriteString(segment.Separator)
 		} else {
 			if idx >= len(row)-1 {
 				if !p.hasRightModules() || p.supportsRightModules() {
 					separatorBackground = p.reset
 				} else if p.hasRightModules() && rowNum >= len(p.Segments)-1 {
 					nextSegment := p.rightPowerline.Segments[0][0]
-					separatorBackground = p.bgColor(nextSegment.background)
+					separatorBackground = p.bgColor(nextSegment.Background)
 				}
 			} else {
 				nextSegment := row[idx+1]
-				separatorBackground = p.bgColor(nextSegment.background)
+				separatorBackground = p.bgColor(nextSegment.Background)
 			}
 		}
-		buffer.WriteString(p.fgColor(segment.foreground))
-		buffer.WriteString(p.bgColor(segment.background))
+		buffer.WriteString(p.fgColor(segment.Foreground))
+		buffer.WriteString(p.bgColor(segment.Background))
 		if !*p.args.Condensed {
 			buffer.WriteRune(' ')
 		}
-		buffer.WriteString(segment.content)
-		numEastAsianRunes += p.numEastAsianRunes(&segment.content)
+		buffer.WriteString(segment.Content)
+		numEastAsianRunes += p.numEastAsianRunes(&segment.Content)
 		if !*p.args.Condensed {
 			buffer.WriteRune(' ')
 		}
 		if !p.isRightPrompt() {
 			buffer.WriteString(separatorBackground)
-			buffer.WriteString(p.fgColor(segment.separatorForeground))
-			buffer.WriteString(segment.separator)
+			buffer.WriteString(p.fgColor(segment.SeparatorForeground))
+			buffer.WriteString(segment.Separator)
 		}
 		buffer.WriteString(p.reset)
 	}

--- a/powerline/powerline.go
+++ b/powerline/powerline.go
@@ -1,0 +1,31 @@
+package powerline
+
+import (
+	runewidth "github.com/mattn/go-runewidth"
+)
+
+// Segment describes an information to display on the command line prompt
+type Segment struct {
+	// Content is the text to be displayed on the command line prompt
+	Content string
+	// Foreground is the text color (see https://misc.flogisoft.com/bash/tip_colors_and_formatting#background1)
+	Foreground uint8
+	// Background is the color of the filling background (see https://misc.flogisoft.com/bash/tip_colors_and_formatting#background1)
+	Background uint8
+	// Separator is the character to be used when generating multiple segments to override the default separator
+	Separator string
+	// SeparatorForeground is the character to be used when generating multiple segments to override the default foreground separator
+	SeparatorForeground uint8
+	// Priority is the priority of the segment. The higher, the less probable the segment will be dropped if the total length is too long
+	Priority int
+	// HideSeparators indicated not to display any separator with next segment.
+	HideSeparators bool
+	Width          int
+}
+
+func (s Segment) ComputeWidth(condensed bool) int {
+	if condensed {
+		return runewidth.StringWidth(s.Content) + runewidth.StringWidth(s.Separator)
+	}
+	return runewidth.StringWidth(s.Content) + runewidth.StringWidth(s.Separator) + 2
+}

--- a/segment-aws.go
+++ b/segment-aws.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 )
 
@@ -12,10 +13,10 @@ func segmentAWS(p *powerline) {
 		if region != "" {
 			r = " (" + region + ")"
 		}
-		p.appendSegment("aws", segment{
-			content:    profile + r,
-			foreground: p.theme.AWSFg,
-			background: p.theme.AWSBg,
+		p.appendSegment("aws", pwl.Segment{
+			Content:    profile + r,
+			Foreground: p.theme.AWSFg,
+			Background: p.theme.AWSBg,
 		})
 	}
 }

--- a/segment-cwd.go
+++ b/segment-cwd.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"sort"
 	"strings"
+
+	pwl "github.com/justjanne/powerline-go/powerline"
 )
 
 const ellipsis = "\u2026"
@@ -166,10 +168,10 @@ func segmentCwd(p *powerline) {
 			cwd = "~" + cwd[len(home):]
 		}
 
-		p.appendSegment("cwd", segment{
-			content:    cwd,
-			foreground: p.theme.CwdFg,
-			background: p.theme.PathBg,
+		p.appendSegment("cwd", pwl.Segment{
+			Content:    cwd,
+			Foreground: p.theme.CwdFg,
+			Background: p.theme.PathBg,
 		})
 	} else {
 		pathSegments := cwdToPathSegments(p, cwd)
@@ -204,19 +206,19 @@ func segmentCwd(p *powerline) {
 			isLastDir := idx == len(pathSegments)-1
 			foreground, background, special := getColor(p, pathSegment, isLastDir)
 
-			segment := segment{
-				content:    escapeVariables(p, maybeShortenName(p, pathSegment.path)),
-				foreground: foreground,
-				background: background,
+			segment := pwl.Segment{
+				Content:    escapeVariables(p, maybeShortenName(p, pathSegment.path)),
+				Foreground: foreground,
+				Background: background,
 			}
 
 			if !special {
 				if p.align == alignRight && p.supportsRightModules() && idx != 0 {
-					segment.separator = p.symbolTemplates.SeparatorReverseThin
-					segment.separatorForeground = p.theme.SeparatorFg
+					segment.Separator = p.symbolTemplates.SeparatorReverseThin
+					segment.SeparatorForeground = p.theme.SeparatorFg
 				} else if (p.align == alignLeft || !p.supportsRightModules()) && !isLastDir {
-					segment.separator = p.symbolTemplates.SeparatorThin
-					segment.separatorForeground = p.theme.SeparatorFg
+					segment.Separator = p.symbolTemplates.SeparatorThin
+					segment.SeparatorForeground = p.theme.SeparatorFg
 				}
 			}
 

--- a/segment-docker.go
+++ b/segment-docker.go
@@ -3,6 +3,8 @@ package main
 import (
 	"net/url"
 	"os"
+
+	pwl "github.com/justjanne/powerline-go/powerline"
 )
 
 func segmentDocker(p *powerline) {
@@ -20,10 +22,10 @@ func segmentDocker(p *powerline) {
 	}
 
 	if docker != "" {
-		p.appendSegment("docker", segment{
-			content:    docker,
-			foreground: p.theme.DockerMachineFg,
-			background: p.theme.DockerMachineBg,
+		p.appendSegment("docker", pwl.Segment{
+			Content:    docker,
+			Foreground: p.theme.DockerMachineFg,
+			Background: p.theme.DockerMachineBg,
 		})
 	}
 }

--- a/segment-dotenv.go
+++ b/segment-dotenv.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 )
 
@@ -15,10 +16,10 @@ func segmentDotEnv(p *powerline) {
 		}
 	}
 	if dotEnv {
-		p.appendSegment("dotenv", segment{
-			content:    "\u2235",
-			foreground: p.theme.DotEnvFg,
-			background: p.theme.DotEnvBg,
+		p.appendSegment("dotenv", pwl.Segment{
+			Content:    "\u2235",
+			Foreground: p.theme.DotEnvFg,
+			Background: p.theme.DotEnvBg,
 		})
 	}
 }

--- a/segment-duration.go
+++ b/segment-duration.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	pwl "github.com/justjanne/powerline-go/powerline"
 )
 
 const (
@@ -26,10 +28,10 @@ const (
 
 func segmentDuration(p *powerline) {
 	if p.args.Duration == nil || *p.args.Duration == "" {
-		p.appendSegment("duration", segment{
-			content:    "No duration",
-			foreground: p.theme.DurationFg,
-			background: p.theme.DurationBg,
+		p.appendSegment("duration", pwl.Segment{
+			Content:    "No duration",
+			Foreground: p.theme.DurationFg,
+			Background: p.theme.DurationBg,
 		})
 		return
 	}
@@ -40,10 +42,10 @@ func segmentDuration(p *powerline) {
 
 	durationFloat, err := strconv.ParseFloat(durationValue, 64)
 	if err != nil {
-		p.appendSegment("duration", segment{
-			content:    fmt.Sprintf("Failed to convert '%s' to a number", *p.args.Duration),
-			foreground: p.theme.DurationFg,
-			background: p.theme.DurationBg,
+		p.appendSegment("duration", pwl.Segment{
+			Content:    fmt.Sprintf("Failed to convert '%s' to a number", *p.args.Duration),
+			Foreground: p.theme.DurationFg,
+			Background: p.theme.DurationBg,
 		})
 		return
 	}
@@ -80,10 +82,10 @@ func segmentDuration(p *powerline) {
 			content = fmt.Sprintf("%d\u00B5s", ns/microseconds)
 		}
 
-		p.appendSegment("duration", segment{
-			content:    content,
-			foreground: p.theme.DurationFg,
-			background: p.theme.DurationBg,
+		p.appendSegment("duration", pwl.Segment{
+			Content:    content,
+			Foreground: p.theme.DurationFg,
+			Background: p.theme.DurationBg,
 		})
 	}
 }

--- a/segment-exitcode.go
+++ b/segment-exitcode.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"strconv"
 )
 
@@ -72,10 +73,10 @@ func segmentExitCode(p *powerline) {
 		} else {
 			meaning = getMeaningFromExitCode(*p.args.PrevError)
 		}
-		p.appendSegment("exit", segment{
-			content:    meaning,
-			foreground: p.theme.CmdFailedFg,
-			background: p.theme.CmdFailedBg,
+		p.appendSegment("exit", pwl.Segment{
+			Content:    meaning,
+			Foreground: p.theme.CmdFailedFg,
+			Background: p.theme.CmdFailedBg,
 		})
 	}
 }

--- a/segment-git.go
+++ b/segment-git.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 	"os/exec"
 	"regexp"
@@ -25,10 +26,10 @@ func (r repoStats) dirty() bool {
 
 func addRepoStatsSegment(p *powerline, nChanges int, symbol string, foreground uint8, background uint8) {
 	if nChanges > 0 {
-		p.appendSegment("git-status", segment{
-			content:    fmt.Sprintf("%d%s", nChanges, symbol),
-			foreground: foreground,
-			background: background,
+		p.appendSegment("git-status", pwl.Segment{
+			Content:    fmt.Sprintf("%d%s", nChanges, symbol),
+			Foreground: foreground,
+			Background: background,
 		})
 	}
 }
@@ -174,10 +175,10 @@ func segmentGit(p *powerline) {
 		stats.stashed = len(strings.Split(out, "\n")) - 1
 	}
 
-	p.appendSegment("git-branch", segment{
-		content:    branch,
-		foreground: foreground,
-		background: background,
+	p.appendSegment("git-branch", pwl.Segment{
+		Content:    branch,
+		Foreground: foreground,
+		Background: background,
 	})
 	stats.addToPowerline(p)
 }

--- a/segment-gitlite.go
+++ b/segment-gitlite.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"strings"
 )
 
@@ -30,9 +31,9 @@ func segmentGitLite(p *powerline) {
 		branch = getGitDetachedBranch(p)
 	}
 
-	p.appendSegment("git-branch", segment{
-		content:    branch,
-		foreground: p.theme.RepoCleanFg,
-		background: p.theme.RepoCleanBg,
+	p.appendSegment("git-branch", pwl.Segment{
+		Content:    branch,
+		Foreground: p.theme.RepoCleanFg,
+		Background: p.theme.RepoCleanBg,
 	})
 }

--- a/segment-hg.go
+++ b/segment-hg.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os/exec"
 	"strings"
 )
@@ -60,10 +61,10 @@ func segmentHg(p *powerline) {
 			content = fmt.Sprintf(branch)
 		}
 
-		p.appendSegment("hg", segment{
-			content:    content,
-			foreground: foreground,
-			background: background,
+		p.appendSegment("hg", pwl.Segment{
+			Content:    content,
+			Foreground: foreground,
+			Background: background,
 		})
 	}
 }

--- a/segment-hostname.go
+++ b/segment-hostname.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/md5"
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 	"strings"
 )
@@ -40,9 +41,9 @@ func segmentHost(p *powerline) {
 		background = p.theme.HostnameBg
 	}
 
-	p.appendSegment("host", segment{
-		content:    hostPrompt,
-		foreground: foreground,
-		background: background,
+	p.appendSegment("host", pwl.Segment{
+		Content:    hostPrompt,
+		Foreground: foreground,
+		Background: background,
 	})
 }

--- a/segment-jobs.go
+++ b/segment-jobs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 	"os/exec"
 	"strconv"
@@ -28,10 +29,10 @@ func segmentJobs(p *powerline) {
 	}
 
 	if nJobs > 0 {
-		p.appendSegment("jobs", segment{
-			content:    fmt.Sprintf("%d", nJobs),
-			foreground: p.theme.JobsFg,
-			background: p.theme.JobsBg,
+		p.appendSegment("jobs", pwl.Segment{
+			Content:    fmt.Sprintf("%d", nJobs),
+			Foreground: p.theme.JobsFg,
+			Background: p.theme.JobsBg,
 		})
 	}
 }

--- a/segment-kube.go
+++ b/segment-kube.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"io/ioutil"
 	"os"
 	"path"
@@ -8,8 +10,6 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-
-	"fmt"
 
 	"gopkg.in/yaml.v2"
 )
@@ -101,10 +101,10 @@ func segmentKube(p *powerline) {
 	kubeIconHasBeenDrawnYet := false
 	if cluster != "" {
 		kubeIconHasBeenDrawnYet = true
-		p.appendSegment("kube-cluster", segment{
-			content:    fmt.Sprintf("⎈ %s", cluster),
-			foreground: p.theme.KubeClusterFg,
-			background: p.theme.KubeClusterBg,
+		p.appendSegment("kube-cluster", pwl.Segment{
+			Content:    fmt.Sprintf("⎈ %s", cluster),
+			Foreground: p.theme.KubeClusterFg,
+			Background: p.theme.KubeClusterBg,
 		})
 	}
 
@@ -113,10 +113,10 @@ func segmentKube(p *powerline) {
 		if !kubeIconHasBeenDrawnYet {
 			content = fmt.Sprintf("⎈ %s", content)
 		}
-		p.appendSegment("kube-namespace", segment{
-			content:    content,
-			foreground: p.theme.KubeNamespaceFg,
-			background: p.theme.KubeNamespaceBg,
+		p.appendSegment("kube-namespace", pwl.Segment{
+			Content:    content,
+			Foreground: p.theme.KubeNamespaceFg,
+			Background: p.theme.KubeNamespaceBg,
 		})
 	}
 }

--- a/segment-load.go
+++ b/segment-load.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"runtime"
 
 	"github.com/shirou/gopsutil/load"
@@ -27,9 +28,9 @@ func segmentLoad(p *powerline) {
 		bg = p.theme.LoadHighBg
 	}
 
-	p.appendSegment("load", segment{
-		content:    fmt.Sprintf("%.2f", a.Load5),
-		foreground: p.theme.LoadFg,
-		background: bg,
+	p.appendSegment("load", pwl.Segment{
+		Content:    fmt.Sprintf("%.2f", a.Load5),
+		Foreground: p.theme.LoadFg,
+		Background: bg,
 	})
 }

--- a/segment-nix-shell.go
+++ b/segment-nix-shell.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 )
 
@@ -10,9 +11,9 @@ func segmentNixShell(p *powerline) {
 	if nixShell == "" {
 		return
 	}
-	p.appendSegment("nix-shell", segment{
-		content:    nixShell,
-		foreground: p.theme.NixShellFg,
-		background: p.theme.NixShellBg,
+	p.appendSegment("nix-shell", pwl.Segment{
+		Content:    nixShell,
+		Foreground: p.theme.NixShellFg,
+		Background: p.theme.NixShellBg,
 	})
 }

--- a/segment-node.go
+++ b/segment-node.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+
+	pwl "github.com/justjanne/powerline-go/powerline"
 )
 
 const pkgfile = "./package.json"
@@ -20,10 +22,10 @@ func segmentNode(p *powerline) {
 		if err == nil {
 			err = json.Unmarshal(raw, &pkg)
 			if err == nil {
-				p.appendSegment("node-version", segment{
-					content:    pkg.Version + " \u2B22",
-					foreground: p.theme.NodeFg,
-					background: p.theme.NodeBg,
+				p.appendSegment("node-version", pwl.Segment{
+					Content:    pkg.Version + " \u2B22",
+					Foreground: p.theme.NodeFg,
+					Background: p.theme.NodeBg,
 				})
 			}
 		}

--- a/segment-perlbrew.go
+++ b/segment-perlbrew.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 	"path"
 )
@@ -12,9 +13,9 @@ func segmentPerlbrew(p *powerline) {
 	}
 
 	envName := path.Base(env)
-	p.appendSegment("perlbrew", segment{
-		content:    envName,
-		foreground: p.theme.PerlbrewFg,
-		background: p.theme.PerlbrewBg,
+	p.appendSegment("perlbrew", pwl.Segment{
+		Content:    envName,
+		Foreground: p.theme.PerlbrewFg,
+		Background: p.theme.PerlbrewBg,
 	})
 }

--- a/segment-plugin.go
+++ b/segment-plugin.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"encoding/json"
+	"os/exec"
+
+	pwl "github.com/justjanne/powerline-go/powerline"
+)
+
+func segmentPlugin(p *powerline, plugin string) bool {
+	output, err := exec.Command("powerline-go-" + plugin).Output()
+	if err != nil {
+		return false
+	}
+	segments := []pwl.Segment{}
+	err = json.Unmarshal(output, &segments)
+	if err != nil {
+		// The plugin was found but no valid data was returned. Ignore it
+		return true
+	}
+	for _, s := range segments {
+		p.appendSegment(plugin, s)
+	}
+	return true
+}

--- a/segment-readonly.go
+++ b/segment-readonly.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -14,10 +15,10 @@ func segmentPerms(p *powerline) {
 		cwd, _ = os.LookupEnv("PWD")
 	}
 	if unix.Access(cwd, unix.W_OK) != nil {
-		p.appendSegment("perms", segment{
-			content:    p.symbolTemplates.Lock,
-			foreground: p.theme.ReadonlyFg,
-			background: p.theme.ReadonlyBg,
+		p.appendSegment("perms", pwl.Segment{
+			Content:    p.symbolTemplates.Lock,
+			Foreground: p.theme.ReadonlyFg,
+			Background: p.theme.ReadonlyBg,
 		})
 	}
 }

--- a/segment-readonly_windows.go
+++ b/segment-readonly_windows.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 )
 
@@ -16,10 +17,10 @@ func segmentPerms(p *powerline) {
 	// Check user's permissions on directory in a portable but probably slower way
 	fileInfo, _ := os.Stat(cwd)
 	if fileInfo.Mode()&W_USR != W_USR {
-		p.appendSegment("perms", segment{
-			content:    p.symbolTemplates.Lock,
-			foreground: p.theme.ReadonlyFg,
-			background: p.theme.ReadonlyBg,
+		p.appendSegment("perms", pwl.Segment{
+			Content:    p.symbolTemplates.Lock,
+			Foreground: p.theme.ReadonlyFg,
+			Background: p.theme.ReadonlyBg,
 		})
 	}
 }

--- a/segment-root.go
+++ b/segment-root.go
@@ -1,5 +1,7 @@
 package main
 
+import pwl "github.com/justjanne/powerline-go/powerline"
+
 func segmentRoot(p *powerline) {
 	var foreground, background uint8
 	if *p.args.PrevError == 0 {
@@ -10,9 +12,9 @@ func segmentRoot(p *powerline) {
 		background = p.theme.CmdFailedBg
 	}
 
-	p.appendSegment("root", segment{
-		content:    p.shellInfo.rootIndicator,
-		foreground: foreground,
-		background: background,
+	p.appendSegment("root", pwl.Segment{
+		Content:    p.shellInfo.rootIndicator,
+		Foreground: foreground,
+		Background: background,
 	})
 }

--- a/segment-shellvar.go
+++ b/segment-shellvar.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 )
 
@@ -10,10 +11,10 @@ func segmentShellVar(p *powerline) {
 
 	if varExists {
 		if varContent != "" {
-			p.appendSegment("shell-var", segment{
-				content:    varContent,
-				foreground: p.theme.ShellVarFg,
-				background: p.theme.ShellVarBg,
+			p.appendSegment("shell-var", pwl.Segment{
+				Content:    varContent,
+				Foreground: p.theme.ShellVarFg,
+				Background: p.theme.ShellVarBg,
 			})
 		} else {
 			warn("Shell variable " + shellVarName + " is empty.")

--- a/segment-ssh.go
+++ b/segment-ssh.go
@@ -1,16 +1,17 @@
 package main
 
 import (
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 )
 
 func segmentSSH(p *powerline) {
 	sshClient, _ := os.LookupEnv("SSH_CLIENT")
 	if sshClient != "" {
-		p.appendSegment("ssh", segment{
-			content:    p.symbolTemplates.Network,
-			foreground: p.theme.SSHFg,
-			background: p.theme.SSHBg,
+		p.appendSegment("ssh", pwl.Segment{
+			Content:    p.symbolTemplates.Network,
+			Foreground: p.theme.SSHFg,
+			Background: p.theme.SSHBg,
 		})
 	}
 }

--- a/segment-subversion.go
+++ b/segment-subversion.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os/exec"
 	"strings"
 )
@@ -11,10 +12,10 @@ var otherModified int
 
 func addSvnRepoStatsSegment(p *powerline, nChanges int, symbol string, foreground uint8, background uint8) {
 	if nChanges > 0 {
-		p.appendSegment("svn-status", segment{
-			content:    fmt.Sprintf("%d%s", nChanges, symbol),
-			foreground: foreground,
-			background: background,
+		p.appendSegment("svn-status", pwl.Segment{
+			Content:    fmt.Sprintf("%d%s", nChanges, symbol),
+			Foreground: foreground,
+			Background: background,
 		})
 	}
 }
@@ -135,10 +136,10 @@ func segmentSubversion(p *powerline) {
 		background = p.theme.RepoCleanBg
 	}
 
-	p.appendSegment("svn-branch", segment{
-		content:    svnInfo["Relative URL"],
-		foreground: foreground,
-		background: background,
+	p.appendSegment("svn-branch", pwl.Segment{
+		Content:    svnInfo["Relative URL"],
+		Foreground: foreground,
+		Background: background,
 	})
 
 	svnStats.addSvnToPowerline(p)

--- a/segment-termtitle.go
+++ b/segment-termtitle.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 	"strings"
 )
@@ -28,9 +29,9 @@ func segmentTermTitle(p *powerline) {
 		title = fmt.Sprintf("\033]0;%s@%s: %s\007", user, host, cwd)
 	}
 
-	p.appendSegment("termtitle", segment{
-		content:        title,
-		priority:       MaxInteger, // do not truncate
-		hideSeparators: true,       // do not draw separators
+	p.appendSegment("termtitle", pwl.Segment{
+		Content:        title,
+		Priority:       MaxInteger, // do not truncate
+		HideSeparators: true,       // do not draw separators
 	})
 }

--- a/segment-terraform_workspace.go
+++ b/segment-terraform_workspace.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"io/ioutil"
 	"os"
 )
@@ -13,10 +14,10 @@ func segmentTerraformWorkspace(p *powerline) {
 	if err == nil && !stat.IsDir() {
 		workspace, err := ioutil.ReadFile(wsFile)
 		if err == nil {
-			p.appendSegment("terraform-workspace", segment{
-				content:    string(workspace),
-				foreground: p.theme.TFWsFg,
-				background: p.theme.TFWsBg,
+			p.appendSegment("terraform-workspace", pwl.Segment{
+				Content:    string(workspace),
+				Foreground: p.theme.TFWsFg,
+				Background: p.theme.TFWsBg,
 			})
 
 		}

--- a/segment-time.go
+++ b/segment-time.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"time"
 )
 
 func segmentTime(p *powerline) {
-	p.appendSegment("time", segment{
-		content:    time.Now().Format("15:04:05"),
-		foreground: p.theme.TimeFg,
-		background: p.theme.TimeBg,
+	p.appendSegment("time", pwl.Segment{
+		Content:    time.Now().Format("15:04:05"),
+		Foreground: p.theme.TimeFg,
+		Background: p.theme.TimeBg,
 	})
 }

--- a/segment-username.go
+++ b/segment-username.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 )
 
@@ -22,9 +23,9 @@ func segmentUser(p *powerline) {
 		background = p.theme.UsernameBg
 	}
 
-	p.appendSegment("user", segment{
-		content:    userPrompt,
-		foreground: p.theme.UsernameFg,
-		background: background,
+	p.appendSegment("user", pwl.Segment{
+		Content:    userPrompt,
+		Foreground: p.theme.UsernameFg,
+		Background: background,
 	})
 }

--- a/segment-vgo.go
+++ b/segment-vgo.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
 )
 
@@ -11,10 +12,16 @@ func segmentVirtualGo(p *powerline) {
 	}
 	if env == "" {
 		return
+	} else {
+		p.appendSegment("vgo", pwl.Segment{
+			Content:    env,
+			Foreground: p.theme.VirtualGoFg,
+			Background: p.theme.VirtualGoBg,
+		})
 	}
-	p.appendSegment("vgo", segment{
-		content:    env,
-		foreground: p.theme.VirtualGoFg,
-		background: p.theme.VirtualGoBg,
+	p.appendSegment("vgo", pwl.Segment{
+		Content:    env,
+		Foreground: p.theme.VirtualGoFg,
+		Background: p.theme.VirtualGoBg,
 	})
 }

--- a/segment-virtualenv.go
+++ b/segment-virtualenv.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 	"path"
+
+	pwl "github.com/justjanne/powerline-go/powerline"
 )
 
 func segmentVirtualEnv(p *powerline) {
@@ -18,11 +20,18 @@ func segmentVirtualEnv(p *powerline) {
 	}
 	if env == "" {
 		return
+	} else {
+		envName := path.Base(env)
+		p.appendSegment("venv", pwl.Segment{
+			Content:    envName,
+			Foreground: p.theme.VirtualEnvFg,
+			Background: p.theme.VirtualEnvBg,
+		})
 	}
 	envName := path.Base(env)
-	p.appendSegment("venv", segment{
-		content:    envName,
-		foreground: p.theme.VirtualEnvFg,
-		background: p.theme.VirtualEnvBg,
+	p.appendSegment("venv", pwl.Segment{
+		Content:    envName,
+		Foreground: p.theme.VirtualEnvFg,
+		Background: p.theme.VirtualEnvBg,
 	})
 }

--- a/themes.go
+++ b/themes.go
@@ -21,7 +21,11 @@ type Symbols struct {
 
 // Theme definitions
 type Theme struct {
-	Reset          uint8
+	Reset uint8
+
+	DefaultFg uint8
+	DefaultBg uint8
+
 	UsernameFg     uint8
 	UsernameBg     uint8
 	UsernameRootBg uint8


### PR DESCRIPTION
Thanks for making this tool, I pretty like it!
May I suggest my contribution which consists of adding support for plugins, command line executables that should dump the segment configuration to stdout.
This allows users to write their own extensions, including using closed source tools to integrate nicely with the rest of the tool.
To allow having a consistent segment dump, the Segment part has been extracted to a sub package, allowing it to be imported from third party softwates.
Here is an example of plugin usage: https://github.com/tjamet/powerline-go-datadog/blob/master/powerline-go-datadog.go#L37