### PR TITLE
add region in AWS segment if AWS_DEFAULT_REGION envvar is set

### DIFF
--- a/segment-aws.go
+++ b/segment-aws.go
@@ -5,10 +5,15 @@ import (
 )
 
 func segmentAWS(p *powerline) {
-	profile, _ := os.LookupEnv("AWS_PROFILE")
+	profile := os.Getenv("AWS_PROFILE")
+	region := os.Getenv("AWS_REGION")
 	if profile != "" {
+		var r string
+		if region != "" {
+			r = " (" + region + ")"
+		}
 		p.appendSegment("aws", segment{
-			content:    profile,
+			content:    profile + r,
 			foreground: p.theme.AWSFg,
 			background: p.theme.AWSBg,
 		})

--- a/segment-aws.go
+++ b/segment-aws.go
@@ -6,7 +6,7 @@ import (
 
 func segmentAWS(p *powerline) {
 	profile := os.Getenv("AWS_PROFILE")
-	region := os.Getenv("AWS_REGION")
+	region := os.Getenv("AWS_DEFAULT_REGION")
 	if profile != "" {
 		var r string
 		if region != "" {


### PR DESCRIPTION
If `AWS_DEFAULT_REGION` and `AWS_PROFILE` are set, they're added in AWS Segment as shown in picture below : 

![image](https://user-images.githubusercontent.com/4520100/55940212-f1be8200-5c3f-11e9-81da-944696ea81dd.png).

I've also changed method to look after env vars, as `error` from `os.LookupEnv` wasn't used, `os.Getenv` is enough.
