### PR TITLE
Ability to force right-only prompt

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -101,8 +101,8 @@ var themes = map[string]Theme{
 		ReadonlyFg: 254,
 		ReadonlyBg: 124,
 
-		SshFg: 254,
-		SshBg: 166, // medium orange
+		SSHFg: 254,
+		SSHBg: 166, // medium orange
 
 		DockerMachineFg: 177, // light purple
 		DockerMachineBg: 55,  // purple
@@ -115,7 +115,7 @@ var themes = map[string]Theme{
 		DotEnvFg: 15, // white
 		DotEnvBg: 55, // purple
 
-		AWSFg: 15, // white
+		AWSFg: 15,  // white
 		AWSBg: 172, // AWS orange
 
 		RepoCleanFg: 0,   // black
@@ -464,8 +464,8 @@ var themes = map[string]Theme{
 		ReadonlyFg: 124,
 		ReadonlyBg: 253,
 
-		SshFg: 166, // medium orange
-		SshBg: 254,
+		SSHFg: 166, // medium orange
+		SSHBg: 254,
 
 		DockerMachineFg: 55,  // purple
 		DockerMachineBg: 177, // light purple
@@ -805,8 +805,8 @@ var themes = map[string]Theme{
 		SeparatorFg:        15,
 		ReadonlyFg:         8,
 		ReadonlyBg:         1,
-		SshFg:              8,
-		SshBg:              9,
+		SSHFg:              8,
+		SSHBg:              9,
 		DockerMachineFg:    13,
 		DockerMachineBg:    55,
 		DotEnvFg:           15,
@@ -1129,8 +1129,8 @@ var themes = map[string]Theme{
 		SeparatorFg:        15,
 		ReadonlyFg:         8,
 		ReadonlyBg:         1,
-		SshFg:              8,
-		SshBg:              9,
+		SSHFg:              8,
+		SSHBg:              9,
 		DockerMachineFg:    13,
 		DockerMachineBg:    55,
 		DotEnvFg:           15,

--- a/main.go
+++ b/main.go
@@ -64,9 +64,8 @@ type args struct {
 func (s segment) computeWidth(condensed bool) int {
 	if condensed {
 		return runewidth.StringWidth(s.content) + runewidth.StringWidth(s.separator)
-	} else {
-		return runewidth.StringWidth(s.content) + runewidth.StringWidth(s.separator) + 2
 	}
+	return runewidth.StringWidth(s.content) + runewidth.StringWidth(s.separator) + 2
 }
 
 func warn(msg string) {
@@ -76,9 +75,8 @@ func warn(msg string) {
 func pathExists(path string) bool {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return false
-	} else {
-		return true
 	}
+	return true
 }
 
 func getValidCwd() string {
@@ -122,7 +120,7 @@ var modules = map[string]func(*powerline){
 	"perms":               segmentPerms,
 	"root":                segmentRoot,
 	"shell-var":           segmentShellVar,
-	"ssh":                 segmentSsh,
+	"ssh":                 segmentSSH,
 	"termtitle":           segmentTermTitle,
 	"terraform-workspace": segmentTerraformWorkspace,
 	"time":                segmentTime,

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ const (
 
 	alignLeft alignment = iota
 	alignRight
+	alignRightForced
 )
 
 type segment struct {
@@ -46,6 +47,7 @@ type args struct {
 	Shell                *string
 	Modules              *string
 	ModulesRight         *string
+	RightOnly            *bool
 	Priority             *string
 	MaxWidthPercentage   *int
 	TruncateSegmentWidth *int
@@ -191,6 +193,10 @@ func main() {
 			"",
 			comments("The list of modules to load anchored to the right, for shells that support it, separated by ','",
 				"(valid choices: aws, cwd, docker, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, root, shell-var, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)")),
+		RightOnly: flag.Bool(
+			"right-only",
+			false,
+			comments("Use only modules-right with forced right alignment ; modules flag is ignored")),
 		Priority: flag.String(
 			"priority",
 			"root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit,cwd-path",
@@ -270,7 +276,12 @@ func main() {
 		priorities[priority] = len(priorityList) - idx
 	}
 
-	p := newPowerline(args, getValidCwd(), priorities, alignLeft)
+	var align = alignLeft
+	if *args.RightOnly {
+		align = alignRightForced
+	}
+
+	p := newPowerline(args, getValidCwd(), priorities, align, false)
 	if p.supportsRightModules() && p.hasRightModules() && !*args.Eval {
 		fmt.Fprintln(os.Stderr, "Flag '-modules-right' requires '-eval' mode.")
 		os.Exit(1)

--- a/powerline.go
+++ b/powerline.go
@@ -95,9 +95,8 @@ func newPowerline(args args, cwd string, priorities map[string]int, align alignm
 func (p *powerline) color(prefix string, code uint8) string {
 	if code == p.theme.Reset {
 		return p.reset
-	} else {
-		return fmt.Sprintf(p.shellInfo.colorTemplate, fmt.Sprintf("[%s;5;%dm", prefix, code))
 	}
+	return fmt.Sprintf(p.shellInfo.colorTemplate, fmt.Sprintf("[%s;5;%dm", prefix, code))
 }
 
 func (p *powerline) fgColor(code uint8) string {
@@ -162,30 +161,30 @@ func (p *powerline) truncateRow(rowNum int) {
 
 		if rowLength > shellMaxLength && *p.args.TruncateSegmentWidth > 0 {
 			minPriorityNotTruncated := MaxInteger
-			minPriorityNotTruncatedSegmentId := -1
+			minPriorityNotTruncatedSegmentID := -1
 			for idx, segment := range row {
 				if segment.width > *p.args.TruncateSegmentWidth && segment.priority < minPriorityNotTruncated {
 					minPriorityNotTruncated = segment.priority
-					minPriorityNotTruncatedSegmentId = idx
+					minPriorityNotTruncatedSegmentID = idx
 				}
 			}
-			for minPriorityNotTruncatedSegmentId != -1 && rowLength > shellMaxLength {
-				segment := row[minPriorityNotTruncatedSegmentId]
+			for minPriorityNotTruncatedSegmentID != -1 && rowLength > shellMaxLength {
+				segment := row[minPriorityNotTruncatedSegmentID]
 
 				rowLength -= segment.width
 
 				segment.content = runewidth.Truncate(segment.content, *p.args.TruncateSegmentWidth-runewidth.StringWidth(segment.separator)-3, "…")
 				segment.width = segment.computeWidth(*p.args.Condensed)
 
-				row = append(append(row[:minPriorityNotTruncatedSegmentId], segment), row[minPriorityNotTruncatedSegmentId+1:]...)
+				row = append(append(row[:minPriorityNotTruncatedSegmentID], segment), row[minPriorityNotTruncatedSegmentID+1:]...)
 				rowLength += segment.width
 
 				minPriorityNotTruncated = MaxInteger
-				minPriorityNotTruncatedSegmentId = -1
+				minPriorityNotTruncatedSegmentID = -1
 				for idx, segment := range row {
 					if segment.width > *p.args.TruncateSegmentWidth && segment.priority < minPriorityNotTruncated {
 						minPriorityNotTruncated = segment.priority
-						minPriorityNotTruncatedSegmentId = idx
+						minPriorityNotTruncatedSegmentID = idx
 					}
 				}
 			}
@@ -193,16 +192,16 @@ func (p *powerline) truncateRow(rowNum int) {
 
 		for rowLength > shellMaxLength {
 			minPriority := MaxInteger
-			minPrioritySegmentId := -1
+			minPrioritySegmentID := -1
 			for idx, segment := range row {
 				if segment.priority < minPriority {
 					minPriority = segment.priority
-					minPrioritySegmentId = idx
+					minPrioritySegmentID = idx
 				}
 			}
-			if minPrioritySegmentId != -1 {
-				segment := row[minPrioritySegmentId]
-				row = append(row[:minPrioritySegmentId], row[minPrioritySegmentId+1:]...)
+			if minPrioritySegmentID != -1 {
+				segment := row[minPrioritySegmentID]
+				row = append(row[:minPrioritySegmentID], row[minPrioritySegmentID+1:]...)
 				rowLength -= segment.width
 			}
 		}
@@ -219,7 +218,7 @@ func (p *powerline) numEastAsianRunes(segmentContent *string) int {
 		switch width.LookupRune(r).Kind() {
 		case width.Neutral:
 		case width.EastAsianAmbiguous:
-			numEastAsianRunes += 1
+			numEastAsianRunes++
 		case width.EastAsianWide:
 		case width.EastAsianNarrow:
 		case width.EastAsianFullwidth:

--- a/segment-cwd.go
+++ b/segment-cwd.go
@@ -132,9 +132,8 @@ func cwdToPathSegments(p *powerline, cwd string) []pathSegment {
 func maybeShortenName(p *powerline, pathSegment string) string {
 	if *p.args.CwdMaxDirSize > 0 && len(pathSegment) > *p.args.CwdMaxDirSize {
 		return pathSegment[:*p.args.CwdMaxDirSize]
-	} else {
-		return pathSegment
 	}
+	return pathSegment
 }
 
 func escapeVariables(p *powerline, pathSegment string) string {

--- a/segment-git.go
+++ b/segment-git.go
@@ -90,13 +90,11 @@ func getGitDetachedBranch(p *powerline) string {
 		out, err := runGitCommand("git", "symbolic-ref", "--short", "HEAD")
 		if err != nil {
 			return "Error"
-		} else {
-			return strings.SplitN(out, "\n", 2)[0]
 		}
-	} else {
-		detachedRef := strings.SplitN(out, "\n", 2)
-		return fmt.Sprintf("%s %s", p.symbolTemplates.RepoDetached, detachedRef[0])
+		return strings.SplitN(out, "\n", 2)[0]
 	}
+	detachedRef := strings.SplitN(out, "\n", 2)
+	return fmt.Sprintf("%s %s", p.symbolTemplates.RepoDetached, detachedRef[0])
 }
 
 func parseGitStats(status []string) repoStats {

--- a/segment-nix-shell.go
+++ b/segment-nix-shell.go
@@ -9,11 +9,10 @@ func segmentNixShell(p *powerline) {
 	nixShell, _ = os.LookupEnv("IN_NIX_SHELL")
 	if nixShell == "" {
 		return
-	} else {
-		p.appendSegment("nix-shell", segment{
-			content:    nixShell,
-			foreground: p.theme.NixShellFg,
-			background: p.theme.NixShellBg,
-		})
 	}
+	p.appendSegment("nix-shell", segment{
+		content:    nixShell,
+		foreground: p.theme.NixShellFg,
+		background: p.theme.NixShellBg,
+	})
 }

--- a/segment-ssh.go
+++ b/segment-ssh.go
@@ -4,13 +4,13 @@ import (
 	"os"
 )
 
-func segmentSsh(p *powerline) {
+func segmentSSH(p *powerline) {
 	sshClient, _ := os.LookupEnv("SSH_CLIENT")
 	if sshClient != "" {
 		p.appendSegment("ssh", segment{
 			content:    p.symbolTemplates.Network,
-			foreground: p.theme.SshFg,
-			background: p.theme.SshBg,
+			foreground: p.theme.SSHFg,
+			background: p.theme.SSHBg,
 		})
 	}
 }

--- a/segment-vgo.go
+++ b/segment-vgo.go
@@ -11,11 +11,10 @@ func segmentVirtualGo(p *powerline) {
 	}
 	if env == "" {
 		return
-	} else {
-		p.appendSegment("vgo", segment{
-			content:    env,
-			foreground: p.theme.VirtualGoFg,
-			background: p.theme.VirtualGoBg,
-		})
 	}
+	p.appendSegment("vgo", segment{
+		content:    env,
+		foreground: p.theme.VirtualGoFg,
+		background: p.theme.VirtualGoBg,
+	})
 }

--- a/segment-virtualenv.go
+++ b/segment-virtualenv.go
@@ -18,12 +18,11 @@ func segmentVirtualEnv(p *powerline) {
 	}
 	if env == "" {
 		return
-	} else {
-		envName := path.Base(env)
-		p.appendSegment("venv", segment{
-			content:    envName,
-			foreground: p.theme.VirtualEnvFg,
-			background: p.theme.VirtualEnvBg,
-		})
 	}
+	envName := path.Base(env)
+	p.appendSegment("venv", segment{
+		content:    envName,
+		foreground: p.theme.VirtualEnvFg,
+		background: p.theme.VirtualEnvBg,
+	})
 }

--- a/themes.go
+++ b/themes.go
@@ -44,8 +44,8 @@ type Theme struct {
 	ReadonlyFg uint8
 	ReadonlyBg uint8
 
-	SshFg uint8
-	SshBg uint8
+	SSHFg uint8
+	SSHBg uint8
 
 	DockerMachineFg uint8
 	DockerMachineBg uint8


### PR DESCRIPTION
When using fish, it's actually not possible to do this :
```fish
function fish_prompt
    eval $GOPATH/bin/powerline-go -shell bare -eval -modules perms,cwd
end

function fish_right_prompt
    set duration (math -s6 "$CMD_DURATION / 1000")
    eval $GOPATH/bin/powerline-go -shell bare -eval -duration $duration -modules-right git,kube,duration
end
```

The goal of this Pull Request is to add a new flag `right-only` which (force SupportRight to be true) doesnt do anything on the left prompt and set the right alignment for the right prompt.