### PR TITLE
Added a custom segment for things I can't imagine

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ Usage of powerline-go:
     	 (default "patched")
   -modules string
     	 The list of modules to load, separated by ','
-    	 (valid choices: aws, cwd, docker, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, root, shell-var, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
+    	 (valid choices: aws, cwd, custom, docker, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, root, shell-var, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
     	 (default "nix-shell,venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root,vgo")
   -modules-right string
     	 The list of modules to load anchored to the right, for shells that support it, separated by ','
-    	 (valid choices: aws, cwd, docker, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, root, shell-var, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
+    	 (valid choices: aws, cwd, custom, docker, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, root, shell-var, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
   -newline
     	 Show the prompt on a new line
   -numeric-exit-codes
@@ -199,7 +199,7 @@ Usage of powerline-go:
     	 Use '~' for your home dir. You may need to escape this character to avoid shell substitution.
   -priority string
     	 Segments sorted by priority, if not enough space exists, the least priorized segments are removed first. Separate with ','
-    	 (valid choices: aws, cwd, docker, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, root, shell-var, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
+    	 (valid choices: aws, cwd, custom, docker, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, root, shell-var, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
     	 (default "root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit,cwd-path")
   -shell string
     	 Set this to your shell type

--- a/main.go
+++ b/main.go
@@ -108,6 +108,7 @@ func getValidCwd() string {
 var modules = map[string]func(*powerline){
 	"aws":                 segmentAWS,
 	"cwd":                 segmentCwd,
+	"custom":              segmentCustom,
 	"docker":              segmentDocker,
 	"dotenv":              segmentDotEnv,
 	"duration":            segmentDuration,
@@ -194,17 +195,17 @@ func main() {
 			"modules",
 			"nix-shell,venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root,vgo",
 			commentsWithDefaults("The list of modules to load, separated by ','",
-				"(valid choices: aws, cwd, docker, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, root, shell-var, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)")),
+				"(valid choices: aws, cwd, custom, docker, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, root, shell-var, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)")),
 		ModulesRight: flag.String(
 			"modules-right",
 			"",
 			comments("The list of modules to load anchored to the right, for shells that support it, separated by ','",
-				"(valid choices: aws, cwd, docker, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, root, shell-var, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)")),
+				"(valid choices: aws, cwd, custom, docker, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, root, shell-var, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)")),
 		Priority: flag.String(
 			"priority",
 			"root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit,cwd-path",
 			commentsWithDefaults("Segments sorted by priority, if not enough space exists, the least priorized segments are removed first. Separate with ','",
-				"(valid choices: aws, cwd, docker, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, root, shell-var, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)")),
+				"(valid choices: aws, cwd, custom, docker, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, root, shell-var, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)")),
 		MaxWidthPercentage: flag.Int(
 			"max-width",
 			0,

--- a/segment-custom.go
+++ b/segment-custom.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"strconv"
+)
+
+func segmentCustom(p *powerline) {
+	customVarContent, customVarExists := os.LookupEnv("POWERLINE_CUSTOM_CONTENT")
+	if customVarExists {
+		customFG, _ := os.LookupEnv("POWERLINE_CUSTOM_FG")
+		fg, _ := strconv.Atoi(customFG)
+		customBG, _ := os.LookupEnv("POWERLINE_CUSTOM_BG")
+		bg, _ := strconv.Atoi(customBG)
+
+		p.appendSegment("custom", segment{
+			content:    customVarContent,
+			foreground: uint8(fg),
+			background: uint8(bg),
+		})
+	}
+}


### PR DESCRIPTION
I would like to give the developers at my company the ability to inject *anything* into the prompt, without writing go code.

With this patch, I'm introducing a new "custom" segment, which allows users to extend their prompt with literally anything by setting custom environment variables:
```
export POWERLINE_CUSTOM_CONTENT="special-mode"
export POWERLINE_CUSTOM_FG="42"
export POWERLINE_CUSTOM_BG="15"
```

I'm planning on using this at my company, but I thought it might be useful to anyone.

I do realize that I'm throwing out errors. If you want I can add warnings when the colors don't convert or whatever?