### PR TITLE
Trim last space in RPROMPT and use evalPromptRightSuffix for RPROMPT

### DIFF
--- a/powerline.go
+++ b/powerline.go
@@ -351,7 +351,8 @@ func (p *powerline) draw() string {
 			}
 		case alignRight:
 			if p.supportsRightModules() {
-				buffer.WriteString(p.shellInfo.evalPromptSuffix)
+				buffer.Truncate(buffer.Len() - 1)
+				buffer.WriteString(p.shellInfo.evalPromptRightSuffix)
 			}
 		}
 		if p.hasRightModules() {


### PR DESCRIPTION
This change puts the RPROMPT at the very end of the line for me