### PR TITLE
Fix regression introduced in ff5bb75f

### DIFF
--- a/segment-duration.go
+++ b/segment-duration.go
@@ -48,7 +48,7 @@ func segmentDuration(p *powerline) {
 		return
 	}
 
-	duration := time.Duration(durationFloat) * time.Second
+	duration := time.Duration(durationFloat * float64(time.Second.Nanoseconds()))
 
 	if duration > 0 {
 		var content string


### PR DESCRIPTION
It looked like the duration were always rounded to the seconds on my terminal. For instance, I got `2s 0ms` or `19s 0ms`.

After digging, I found that the `-duration` argument, which is a float representing the number of seconds, is first converted to a `Duration` with `time.Duration()`. The given argument is the duration in nanoseconds and thus the decimal part is lost. Then it is multiplied to get back seconds.

The fix is to multiply before creating the `Duration` object so that the duration is not lost. Now I have a better precision, and duration is always displayed, even under the second (I used to think there was a threshold of 1 second)

I am not very fluent in Go so there may be better ways to do it. Feel free to modify.