### PR TITLE
Adds eval in README for fish shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Redefine `fish_prompt` in `~/.config/fish/config.fish`:
 
 ```bash
 function fish_prompt
-    $GOPATH/bin/powerline-go -error $status -shell bare
+    eval $GOPATH/bin/powerline-go -error $status -shell bare
 end
 ```
 ### Nix


### PR DESCRIPTION
fish version 2.7.x complains about not having eval in front of the powerline-go command and shows nothing from the powerline. An eval, who might have guessed that ;), fixes this.