### PR TITLE
segment-kube: use context instead of cluster name

### DIFF
--- a/segment-kube.go
+++ b/segment-kube.go
@@ -70,7 +70,7 @@ func segmentKube(p *powerline) {
 	namespace := ""
 	for _, context := range config.Contexts {
 		if context.Name == config.CurrentContext {
-			cluster = context.Context.Cluster
+			cluster = context.Name
 			namespace = context.Context.Namespace
 			break
 		}


### PR DESCRIPTION
Hi @justjanne 

I have an improvement for the kube module.

Currently, the kube module print the name of the chosen Kubernetes cluster. I find it a little bit reductive and misleading since it will be much more appropriate to print the context name instead of the cluster one.

By definition a context is a combination of a cluster and a user. Thus, printing only the cluster name doesn't give any clue of which user is used to interact with the cluster.

Suppose the following config :
```
contexts:
- context:
    cluster: my-cluster-name
    user: my-user-2
  name: my-context-name-2
- context:
    cluster: my-cluster-name
    user: my-user
  name: my-context-name
current-context: my-context-name
```
The cluster remains the same but the user is different.

My pull request print the context name instead of the cluster name.

Note that this change will not impact the `shorten-gke/eks-names` (by default, context is equal to cluster name).