### PR TITLE
Added a check for stash before executing git stash list for performance

### DIFF
--- a/segment-git.go
+++ b/segment-git.go
@@ -168,9 +168,12 @@ func segmentGit(p *powerline) {
 		background = p.theme.RepoCleanBg
 	}
 
-	out, err = runGitCommand("git", "stash", "list")
-	if err != nil {
-		return
+	out, err = runGitCommand("git", "rev-parse", "--verify", "--quiet", "refs/stash")
+	if err == nil {
+		out, err = runGitCommand("git", "stash", "list")
+		if err != nil {
+			return
+		}
 	}
 	if len(out) > 0 {
 		stats.stashed = len(strings.Split(out, "\n")) - 1


### PR DESCRIPTION
# Background

I noticed that when in Git repositories the prompt would delay for roughly a half a second before returning.

![image](https://user-images.githubusercontent.com/18205030/70539718-f01fc380-1b18-11ea-9863-fc4623557a13.png)

Running WSL1 on the Windows 1909 release, other version details:
```bash
$ git --version
git version 2.17.1
$ lsb_release -a
…
Description:    Ubuntu 18.04.1 LTS
```

Also somewhat discussed in issue #129 - Latency

# Investigation

I walked `segment-git.go` and tried out the commands it would issue. That is where I found that `git stash list` takes considerably longer.

Diving into the source for Git (for the 2.17 release) I found that git stash would call a shell script that added overhead. I also found the script provides a quick method to check if a stash existed, see https://github.com/git/git/blob/6e9e91e9cae74cd7feb9300563d40361b2b17dd2/git-stash.sh#L379

# Changes

I simply added the check for a stash. The command raises an error if there is no stash.

This also means that if a stash exists, performance will regress
![image](https://user-images.githubusercontent.com/18205030/70542883-5d822300-1b1e-11ea-9e13-a6ea0cc17b9d.png)
