### PR TITLE
add -indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ Usage of ./powerline-go:
   -ignore-repos string
          A list of git repos to ignore. Separate with ','.
          Repos are identified by their root directory.
+  -indicators string
+         One or more indicator from a path. Separate with ','.
+         An indicator add to default indicator from a path like /python a char.
+         Specify these as key/value pairs like /python=🐍.
   -max-width int
          Maximum width of the shell that the prompt may use, in percent. Setting this to 0 disables the shrinking subsystem.
   -mode string

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ type args struct {
 	ShortenEKSNames       *bool
 	ShellVar              *string
 	PathAliases           *string
+	Indicators            *string
 	Duration              *string
 	DurationMin           *string
 	Eval                  *bool
@@ -229,6 +230,12 @@ func main() {
 				"An alias maps a path like foo/bar/baz to a short name like FBB.",
 				"Specify these as key/value pairs like foo/bar/baz=FBB.",
 				"Use '~' for your home dir. You may need to escape this character to avoid shell substitution.")),
+		Indicators: flag.String(
+			"indicators",
+			"",
+			comments("One or more indicator from a path. Separate with ','.",
+				"An indicator add to default indicator from a path like /python a char.",
+				"Specify these as key/value pairs like /python=🐍.")),
 		Duration: flag.String(
 			"duration",
 			"",

--- a/powerline.go
+++ b/powerline.go
@@ -68,14 +68,19 @@ func newPowerline(args args, cwd string, priorities map[string]int, align alignm
 		kv := strings.SplitN(pa, "=", 2)
 		p.pathAliases[kv[0]] = kv[1]
 	}
+	ico := ""
+	cwdl := strings.ToLower(cwd)
 	for _, pa := range strings.Split(*args.Indicators, ",") {
 		if pa == "" {
 			continue
 		}
 		kv := strings.SplitN(pa, "=", 2)
-		if strings.Index(cwd, kv[0]) > -1 {
-			p.shellInfo.rootIndicator = fmt.Sprintf("%s %s", kv[1], p.shellInfo.rootIndicator)
+		if strings.Index(cwdl, kv[0]) > -1 {
+			ico = kv[1]
 		}
+	}
+	if ico != "" {
+		p.shellInfo.rootIndicator = fmt.Sprintf("%s %s", ico, p.shellInfo.rootIndicator)
 	}
 	p.Segments = make([][]pwl.Segment, 1)
 	var mods string

--- a/powerline.go
+++ b/powerline.go
@@ -68,6 +68,15 @@ func newPowerline(args args, cwd string, priorities map[string]int, align alignm
 		kv := strings.SplitN(pa, "=", 2)
 		p.pathAliases[kv[0]] = kv[1]
 	}
+	for _, pa := range strings.Split(*args.Indicators, ",") {
+		if pa == "" {
+			continue
+		}
+		kv := strings.SplitN(pa, "=", 2)
+		if strings.Index(cwd, kv[0]) > -1 {
+			p.shellInfo.rootIndicator = fmt.Sprintf("%s %s", kv[1], p.shellInfo.rootIndicator)
+		}
+	}
 	p.Segments = make([][]pwl.Segment, 1)
 	var mods string
 	if p.align == alignLeft {


### PR DESCRIPTION
**-indicators**
as -path-aliases but for add icon to prompt (p.shellInfo.rootIndicator)

example: 
-indicators /.ssh=🔐,/python=🐍,/go/=🔵