### PR TITLE
Add optional timeout for vcs segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ Usage of ./powerline-go:
   -truncate-segment-width int
          Minimum width of a segment, segments longer than this will be shortened if space is limited. Setting this to 0 disables it.
          (default 16)
+  -vcs-timeout int
+         Maximum time in milliseconds to spend generating vcs segments.
+         If generating a vcs segment takes longer than the timeout some elements will be skipped.
+         Setting this to 0 disables the timeout.
 ```
 ### Eval
 

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ type args struct {
 	DurationMin           *string
 	Eval                  *bool
 	Condensed             *bool
+	VCSTimeout            *int
 }
 
 func warn(msg string) {
@@ -245,6 +246,12 @@ func main() {
 			"condensed",
 			false,
 			comments("Remove spacing between segments")),
+		VCSTimeout: flag.Int(
+			"vcs-timeout",
+			0,
+			comments("Maximum time in milliseconds to spend generating vcs segments.",
+				"If generating a vcs segment takes longer than the timeout some elements will be skipped.",
+				"Setting this to 0 disables the timeout.")),
 	}
 	flag.Parse()
 	if strings.HasSuffix(*args.Theme, ".json") {

--- a/segment-gitlite.go
+++ b/segment-gitlite.go
@@ -6,8 +6,11 @@ import (
 )
 
 func segmentGitLite(p *powerline) {
+	ctx, cancel := newVCSContext(p)
+	defer cancel()
+
 	if len(p.ignoreRepos) > 0 {
-		out, err := runGitCommand("git", "rev-parse", "--show-toplevel")
+		out, err := runGitCommand(ctx, "git", "rev-parse", "--show-toplevel")
 		if err != nil {
 			return
 		}
@@ -17,7 +20,7 @@ func segmentGitLite(p *powerline) {
 		}
 	}
 
-	out, err := runGitCommand("git", "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := runGitCommand(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		return
 	}
@@ -28,7 +31,7 @@ func segmentGitLite(p *powerline) {
 	if status != "HEAD" {
 		branch = status
 	} else {
-		branch = getGitDetachedBranch(p)
+		branch = getGitDetachedBranch(ctx, p)
 	}
 
 	p.appendSegment("git-branch", pwl.Segment{

--- a/segment-hg.go
+++ b/segment-hg.go
@@ -1,18 +1,19 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	pwl "github.com/justjanne/powerline-go/powerline"
 	"os/exec"
 	"strings"
 )
 
-func getHgStatus() (bool, bool, bool) {
+func getHgStatus(ctx context.Context) (bool, bool, bool) {
 	hasModifiedFiles := false
 	hasUntrackedFiles := false
 	hasMissingFiles := false
 
-	out, err := exec.Command("hg", "status").Output()
+	out, err := exec.CommandContext(ctx, "hg", "status").Output()
 	if err == nil {
 		output := strings.Split(string(out), "\n")
 		for _, line := range output {
@@ -31,11 +32,14 @@ func getHgStatus() (bool, bool, bool) {
 }
 
 func segmentHg(p *powerline) {
-	out, _ := exec.Command("hg", "branch").Output()
+	ctx, cancel := newVCSContext(p)
+	defer cancel()
+
+	out, _ := exec.CommandContext(ctx, "hg", "branch").Output()
 	output := strings.SplitN(string(out), "\n", 2)
 	if len(output) > 0 && output[0] != "" {
 		branch := output[0]
-		hasModifiedFiles, hasUntrackedFiles, hasMissingFiles := getHgStatus()
+		hasModifiedFiles, hasUntrackedFiles, hasMissingFiles := getHgStatus(ctx)
 
 		var foreground, background uint8
 		var content string


### PR DESCRIPTION
I have some larger git repositories that cause the git segment to take about a second to generate on a 2013 MacBook Pro. For these repositories, I don't want to have to wait one second between commands. This PR adds an option `-vcs-timeout` to set a limit on how long is spent on each of the vcs segments (git, gitlite, hg, subversion).