### PR TITLE
Remove duplicated venv segment in powerline

### DIFF
--- a/segment-virtualenv.go
+++ b/segment-virtualenv.go
@@ -28,10 +28,4 @@ func segmentVirtualEnv(p *powerline) {
 			Background: p.theme.VirtualEnvBg,
 		})
 	}
-	envName := path.Base(env)
-	p.appendSegment("venv", pwl.Segment{
-		Content:    envName,
-		Foreground: p.theme.VirtualEnvFg,
-		Background: p.theme.VirtualEnvBg,
-	})
 }


### PR DESCRIPTION
When using anaconda environments, the name of the environment was being printed twice in the powerline status bar. This edit removes the last few lines of code so that the environment name only appears once. See issue #172