### PR TITLE
don't add venv segment twice

### DIFF
--- a/segment-virtualenv.go
+++ b/segment-virtualenv.go
@@ -28,10 +28,4 @@ func segmentVirtualEnv(p *powerline) {
 			Background: p.theme.VirtualEnvBg,
 		})
 	}
-	envName := path.Base(env)
-	p.appendSegment("venv", pwl.Segment{
-		Content:    envName,
-		Foreground: p.theme.VirtualEnvFg,
-		Background: p.theme.VirtualEnvBg,
-	})
 }


### PR DESCRIPTION
The current code causes the virtualenv segment to appear twice as shown bellow

![Screenshot_20200216_165408](https://user-images.githubusercontent.com/544545/74614367-f617bf00-50dc-11ea-9923-4df80083cd7c.png)

This fixes that so it's only shown once
