### PR TITLE
Show hostname only on SSH connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Usage of ./powerline-go:
          Exit code of previously executed command
   -eval
          Output prompt in 'eval' format.
+  -hostname-only-if-ssh
+         Show hostname only for SSH connection
   -ignore-repos string
          A list of git repos to ignore. Separate with ','.
          Repos are identified by their root directory.

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ type args struct {
 	CwdMaxDepth           *int
 	CwdMaxDirSize         *int
 	ColorizeHostname      *bool
+	HostnameOnlyIfSSH     *bool
 	EastAsianWidth        *bool
 	PromptOnNewLine       *bool
 	StaticPromptIndicator *bool
@@ -147,6 +148,10 @@ func main() {
 			"colorize-hostname",
 			false,
 			comments("Colorize the hostname based on a hash of itself")),
+		HostnameOnlyIfSSH: flag.Bool(
+			"hostname-only-if-ssh",
+			false,
+			comments("Show hostname only for SSH connection")),
 		EastAsianWidth: flag.Bool(
 			"east-asian-width",
 			false,

--- a/segment-hostname.go
+++ b/segment-hostname.go
@@ -21,6 +21,14 @@ func getMd5(text string) []byte {
 func segmentHost(p *powerline) {
 	var hostPrompt string
 	var foreground, background uint8
+
+	if *p.args.HostnameOnlyIfSSH {
+		if os.Getenv("SSH_CLIENT") == "" {
+			// It's not an ssh connection do nothing
+			return
+		}
+	}
+
 	if *p.args.ColorizeHostname {
 		hostName := getHostName()
 		hostPrompt = hostName


### PR DESCRIPTION

<img width="405" alt="Screen Shot 2020-03-15 at 1 16 30 PM" src="https://user-images.githubusercontent.com/9965118/76697615-57708500-66bf-11ea-86ec-cad673e103e9.png">
Added flag to support show hostname only for SSH connections.
Please look at https://github.com/justjanne/powerline-go/issues/150

flag introduced hostname-only-if-ssh
Below is the test done
 ~  $  export SSH_CLIENT=vijay
 ☎  ~  Vijayas-MacBook-Pro  $   export SSH_CLIENT=
 ~  $ 