### PR TITLE
Use cross platform method to obtain user name

### DIFF
--- a/segment-termtitle.go
+++ b/segment-termtitle.go
@@ -5,9 +5,11 @@ package main
 
 import (
 	"fmt"
-	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
+	"os/user"
 	"strings"
+
+	pwl "github.com/justjanne/powerline-go/powerline"
 )
 
 func segmentTermTitle(p *powerline) {
@@ -23,10 +25,16 @@ func segmentTermTitle(p *powerline) {
 	} else if *p.args.Shell == "zsh" {
 		title = "%{\033]0;%n@%m: %~\007%}"
 	} else {
-		user := os.Getenv("USER")
-		host, _ := os.Hostname()
+		userName, found := os.LookupEnv("USER")
+		if !found {
+			userInfo, err := user.Current()
+			if err == nil {
+				userName = userInfo.Username
+			}
+		}
+		hostName, _ := os.Hostname()
 		cwd := p.cwd
-		title = fmt.Sprintf("\033]0;%s@%s: %s\007", user, host, cwd)
+		title = fmt.Sprintf("\033]0;%s@%s: %s\007", userName, hostName, cwd)
 	}
 
 	p.appendSegment("termtitle", pwl.Segment{

--- a/segment-username.go
+++ b/segment-username.go
@@ -1,8 +1,10 @@
 package main
 
 import (
-	pwl "github.com/justjanne/powerline-go/powerline"
 	"os"
+	"os/user"
+
+	pwl "github.com/justjanne/powerline-go/powerline"
 )
 
 func segmentUser(p *powerline) {
@@ -12,8 +14,14 @@ func segmentUser(p *powerline) {
 	} else if *p.args.Shell == "zsh" {
 		userPrompt = "%n"
 	} else {
-		user, _ := os.LookupEnv("USER")
-		userPrompt = user
+		if userName, found := os.LookupEnv("USER"); found {
+			userPrompt = userName
+		} else {
+			userInfo, err := user.Current()
+			if err == nil {
+				userPrompt = userInfo.Username
+			}
+		}
 	}
 
 	var background uint8


### PR DESCRIPTION
Using this enable a simple integration with other shells like powershell.

Today to use powerline-go on powershell I have to setup the USER environment variable (that does not exist on Windows).