### PR TITLE
Test if user has admin privileges (is root) on Windows.

### DIFF
--- a/powerline.go
+++ b/powerline.go
@@ -32,6 +32,7 @@ type powerline struct {
 	args                   args
 	cwd                    string
 	userInfo               user.User
+	userIsAdmin            bool
 	hostname               string
 	username               string
 	pathAliases            map[string]string
@@ -76,6 +77,7 @@ func newPowerline(args args, cwd string, priorities map[string]int, align alignm
 			p.username = usernameWithAd[1]
 		}
 	}
+	p.userIsAdmin = userIsAdmin()
 
 	p.theme = themes[*args.Theme]
 	p.shellInfo = shellInfos[*args.Shell]

--- a/segment-username.go
+++ b/segment-username.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	pwl "github.com/justjanne/powerline-go/powerline"
-	"os"
 )
 
 func segmentUser(p *powerline) []pwl.Segment {
@@ -16,7 +15,7 @@ func segmentUser(p *powerline) []pwl.Segment {
 	}
 
 	var background uint8
-	if os.Getuid() == 0 {
+	if p.userIsAdmin {
 		background = p.theme.UsernameRootBg
 	} else {
 		background = p.theme.UsernameBg

--- a/user-is-admin.go
+++ b/user-is-admin.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package main
+
+import (
+	"os"
+)
+
+func userIsAdmin() bool {
+	return os.Getuid() == 0
+}

--- a/user-is-admin_windows.go
+++ b/user-is-admin_windows.go
@@ -1,0 +1,33 @@
+// +build windows
+
+package main
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func userIsAdmin() bool {
+	var sid *windows.SID
+
+	err := windows.AllocateAndInitializeSid(
+		&windows.SECURITY_NT_AUTHORITY,
+		2,
+		windows.SECURITY_BUILTIN_DOMAIN_RID,
+		windows.DOMAIN_ALIAS_RID_ADMINS,
+		0, 0, 0, 0, 0, 0,
+		&sid,
+	)
+	if err != nil {
+		return false
+	}
+	defer windows.FreeSid(sid)
+
+	t := windows.Token(0)
+
+	member, err := t.IsMember(sid)
+	if err != nil {
+		return false
+	}
+
+	return member
+}


### PR DESCRIPTION
This pull request implement the "root" test on Windows to colorize the username segment (on linux user is printed with red background if it is root).

It does the test is the process has elevated privilege using the [GetTokenInformation](https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-gettokeninformation) API with the `TokenElevation` parameter.

Code based on stackoverflow [answer](https://stackoverflow.com/a/8196291/783118).
