### PR TITLE
venv: fall back to PYENV_VERSION

### DIFF
--- a/segment-virtualenv.go
+++ b/segment-virtualenv.go
@@ -18,6 +18,9 @@ func segmentVirtualEnv(p *powerline) []pwl.Segment {
 	if env == "" {
 		env, _ = os.LookupEnv("CONDA_DEFAULT_ENV")
 	}
+	if env == "" {
+		env, _ = os.LookupEnv("PYENV_VERSION")
+	}
 	segments := []pwl.Segment{}
 	if env != "" {
 		envName := path.Base(env)


### PR DESCRIPTION
Even though not strictly a virtualenv, it is of similar nature and
showing it would be good in case one is active when a "real" virtualenv
is not.