### PR TITLE
Adding GitDisableStats flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ Usage of powerline-go:
     	 Output prompt in 'eval' format.
   -git-assume-unchanged-size int
     	 Disable checking for changed/edited files in git repositories where the index is larger than this size (in KB), improves performance (default 2048)
+  -git-disable-stats string
+    	 Comma-separated list to disable individual git statuses
+    	 (valid choices: ahead, behind, staged, notStaged, untracked, conflicted, stashed)
   -hostname-only-if-ssh
     	 Show hostname only for SSH connections
   -ignore-repos string

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ type args struct {
 	PromptOnNewLine        *bool
 	StaticPromptIndicator  *bool
 	GitAssumeUnchangedSize *int64
+	GitDisableStats        *string
 	Mode                   *string
 	Theme                  *string
 	Shell                  *string
@@ -179,6 +180,11 @@ func main() {
 			"git-assume-unchanged-size",
 			2048,
 			comments("Disable checking for changed/edited files in git repositories where the index is larger than this size (in KB), improves performance")),
+		GitDisableStats: flag.String(
+			"git-disable-stats",
+			"",
+			commentsWithDefaults("Comma-separated list to disable individual git statuses",
+				"(valid choices: ahead, behind, staged, notStaged, untracked, conflicted, stashed)")),
 		Mode: flag.String(
 			"mode",
 			"patched",

--- a/segment-git.go
+++ b/segment-git.go
@@ -38,6 +38,26 @@ func addRepoStatsSegment(nChanges int, symbol string, foreground uint8, backgrou
 }
 
 func (r repoStats) GitSegments(p *powerline) (segments []pwl.Segment) {
+	ignoreStats := strings.Split(*p.args.GitDisableStats, ",")
+	for _, stat := range ignoreStats {
+		// "ahead, behind, staged, notStaged, untracked, conflicted, stashed"
+		switch stat {
+		case "ahead":
+			r.ahead = 0
+		case "behind":
+			r.behind = 0
+		case "staged":
+			r.staged = 0
+		case "notStaged":
+			r.notStaged = 0
+		case "untracked":
+			r.untracked = 0
+		case "conflicted":
+			r.conflicted = 0
+		case "stashed":
+			r.stashed = 0
+		}
+	}
 	segments = append(segments, addRepoStatsSegment(r.ahead, p.symbolTemplates.RepoAhead, p.theme.GitAheadFg, p.theme.GitAheadBg)...)
 	segments = append(segments, addRepoStatsSegment(r.behind, p.symbolTemplates.RepoBehind, p.theme.GitBehindFg, p.theme.GitBehindBg)...)
 	segments = append(segments, addRepoStatsSegment(r.staged, p.symbolTemplates.RepoStaged, p.theme.GitStagedFg, p.theme.GitStagedBg)...)


### PR DESCRIPTION
Closes #197 

New flag `-git-disbale-stats <item>,<item>`
Where item is in [ahead, behind, staged, notStaged, untracked, conflicted, stashed]
Hides that gitSegment section