### PR TITLE
venv option to only show indicator instead of name

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -18,6 +18,8 @@ var symbolTemplates = map[string]Symbols{
 		RepoUntracked:  "+",
 		RepoConflicted: "\u273C",
 		RepoStashed:    "\u2691",
+
+		VenvIndicator: "\uE235",
 	},
 	"patched": {
 		Lock:                 "\uE0A2",
@@ -37,6 +39,8 @@ var symbolTemplates = map[string]Symbols{
 		RepoUntracked:  "+",
 		RepoConflicted: "\u273C",
 		RepoStashed:    "\u2691",
+
+		VenvIndicator: "\uE235",
 	},
 	"flat": {
 		RepoDetached:   "\u2693",
@@ -47,6 +51,8 @@ var symbolTemplates = map[string]Symbols{
 		RepoUntracked:  "+",
 		RepoConflicted: "\u273C",
 		RepoStashed:    "\u2691",
+
+		VenvIndicator: "\uE235",
 	},
 }
 

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ type args struct {
 	EastAsianWidth         *bool
 	PromptOnNewLine        *bool
 	StaticPromptIndicator  *bool
+	VenvNameSizeLimit      *int
 	GitAssumeUnchangedSize *int64
 	Mode                   *string
 	Theme                  *string
@@ -175,6 +176,10 @@ func main() {
 			"static-prompt-indicator",
 			false,
 			comments("Always show the prompt indicator with the default color, never with the error color")),
+		VenvNameSizeLimit: flag.Int(
+			"venv-name-size-limit",
+			0,
+			comments("Show indicator instead of virtualenv name if name is longer than this limit (defaults to 0, which is unlimited)")),
 		GitAssumeUnchangedSize: flag.Int64(
 			"git-assume-unchanged-size",
 			2048,

--- a/segment-virtualenv.go
+++ b/segment-virtualenv.go
@@ -24,6 +24,9 @@ func segmentVirtualEnv(p *powerline) []pwl.Segment {
 	segments := []pwl.Segment{}
 	if env != "" {
 		envName := path.Base(env)
+		if *p.args.VenvNameSizeLimit > 0 && len(envName) > *p.args.VenvNameSizeLimit {
+			envName = p.symbolTemplates.VenvIndicator
+		}
 		segments = append(segments, pwl.Segment{
 			Name:       "venv",
 			Content:    envName,
@@ -31,5 +34,5 @@ func segmentVirtualEnv(p *powerline) []pwl.Segment {
 			Background: p.theme.VirtualEnvBg,
 		})
 	}
-    return segments
+	return segments
 }

--- a/themes.go
+++ b/themes.go
@@ -19,6 +19,8 @@ type Symbols struct {
 	RepoUntracked  string
 	RepoConflicted string
 	RepoStashed    string
+
+	VenvIndicator string
 }
 
 // Theme definitions


### PR DESCRIPTION
Some virtualenvs have very long names, crowding the prompt. This change
adds a flag to have the venv segment simply indicate that a virtualenv
is active.