### PR TITLE
Add WSL segment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,11 +220,11 @@ Usage of powerline-go:
     	 (default "patched")
   -modules string
     	 The list of modules to load, separated by ','
-    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
+    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, wsl)
     	 (default "venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root")
   -modules-right string
     	 The list of modules to load anchored to the right, for shells that support it, separated by ','
-    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
+    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, wsl)
   -newline
     	 Show the prompt on a new line
   -numeric-exit-codes

--- a/defaults.go
+++ b/defaults.go
@@ -72,7 +72,7 @@ var shellInfos = map[string]ShellInfo{
 		evalPromptRightSuffix: `"`,
 	},
 	"bare": {
-		colorTemplate:    "%s",
+		colorTemplate: "%s",
 		rootIndicator:    "$",
 		escapedBackslash: `\`,
 		escapedBacktick:  "`",
@@ -117,6 +117,9 @@ var themes = map[string]Theme{
 		KubeClusterBg:   26,
 		KubeNamespaceFg: 170,
 		KubeNamespaceBg: 17,
+
+		WSLMachineFg: 250, // light grey
+		WSLMachineBg: 238, // dark grey
 
 		DotEnvFg: 15, // white
 		DotEnvBg: 55, // purple
@@ -1494,9 +1497,9 @@ var themes = map[string]Theme{
 		ReadonlyBg:         gruvbox_bright_red,
 		SSHFg:              gruvbox_light0,
 		SSHBg:              gruvbox_faded_purple,
-		DockerMachineFg:    gruvbox_light0, // match ssh-fg
+		DockerMachineFg:    gruvbox_light0,       // match ssh-fg
 		DockerMachineBg:    gruvbox_faded_purple, // match ssh-bg
-		DotEnvFg:           gruvbox_light0, // match ssh-fg
+		DotEnvFg:           gruvbox_light0,       // match ssh-fg
 		DotEnvBg:           gruvbox_faded_purple, // match ssh-bg
 		RepoCleanFg:        gruvbox_dark1,
 		RepoCleanBg:        gruvbox_faded_green,
@@ -1526,16 +1529,16 @@ var themes = map[string]Theme{
 		GitStashedBg:       gruvbox_neutral_yellow,
 		VirtualEnvFg:       gruvbox_light0,
 		VirtualEnvBg:       gruvbox_faded_green,
-		PerlbrewFg:         gruvbox_light0,  // match virtualenv
+		PerlbrewFg:         gruvbox_light0,      // match virtualenv
 		PerlbrewBg:         gruvbox_faded_green, // match virtualenv
-		PlEnvFg:            gruvbox_light0,  // match virtualenv
+		PlEnvFg:            gruvbox_light0,      // match virtualenv
 		PlEnvBg:            gruvbox_faded_green, // match virtualenv
 		TimeFg:             gruvbox_light2,
 		TimeBg:             gruvbox_dark4,
-		ShellVarFg:         gruvbox_light0,  // match ssh-fg
-		ShellVarBg:         gruvbox_faded_purple,  // match ssh-bg
-		NodeFg:             gruvbox_light0,      // match virtualenv
-		NodeBg:             gruvbox_faded_green, // match virtualenv
+		ShellVarFg:         gruvbox_light0,       // match ssh-fg
+		ShellVarBg:         gruvbox_faded_purple, // match ssh-bg
+		NodeFg:             gruvbox_light0,       // match virtualenv
+		NodeBg:             gruvbox_faded_green,  // match virtualenv
 		LoadFg:             gruvbox_light0,
 		LoadBg:             gruvbox_faded_purple,
 		LoadHighBg:         gruvbox_neutral_red,

--- a/main.go
+++ b/main.go
@@ -125,6 +125,7 @@ var modules = map[string]func(*powerline) []pwl.Segment{
 	"user":                segmentUser,
 	"venv":                segmentVirtualEnv,
 	"vgo":                 segmentVirtualGo,
+	"wsl":                 segmentWSL,
 	"nix-shell":           segmentNixShell,
 }
 

--- a/segment-wsl.go
+++ b/segment-wsl.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"net/url"
+	"os"
+
+	pwl "github.com/justjanne/powerline-go/powerline"
+)
+
+func segmentWSL(p *powerline) []pwl.Segment {
+	var WSL string
+	WSLMachineName, _ := os.LookupEnv("WSL_DISTRO_NAME")
+	WSLHost, _ := os.LookupEnv("NAME")
+
+	if WSLMachineName != "" {
+		WSL = WSLMachineName
+	} else if WSLHost != " " {
+		u, err := url.Parse(WSLHost)
+		if err == nil {
+			WSL = u.Host
+		}
+	}
+
+	if WSL != "" {
+		return []pwl.Segment{{
+			Name:       "WSL",
+			Content:    WSL,
+			Foreground: p.theme.WSLMachineFg,
+			Background: p.theme.WSLMachineBg,
+		}}
+	}
+	return []pwl.Segment{}
+}

--- a/themes.go
+++ b/themes.go
@@ -63,6 +63,9 @@ type Theme struct {
 	KubeNamespaceFg uint8
 	KubeNamespaceBg uint8
 
+	WSLMachineFg uint8
+	WSLMachineBg uint8
+
 	DotEnvFg uint8
 	DotEnvBg uint8
 

--- a/themes/default.json
+++ b/themes/default.json
@@ -20,6 +20,8 @@
   "SshBg": 166,
   "DockerMachineFg": 177,
   "DockerMachineBg": 55,
+  "WSLMachineFg": 250,
+  "WSLMachineBg": 238,
   "DotEnvFg": 15,
   "DotEnvBg": 55,
   "RepoCleanFg": 0,


### PR DESCRIPTION
- Read environment variable WSL_DISTRO_NAME or failover to NAME.

----
Treat WSL distro instances similar to docker, AWS and other similar container environments. Utilized hostname scheme.

`RStudioTest` is the WSL_DISTRO_NAME in this example:
![image](https://user-images.githubusercontent.com/2185020/83815728-7ceda900-a686-11ea-85cd-1de4900021a7.png)
