### PR TITLE
A possible fix for #176 (added StaticPromptIndicator to non-newline prompt) 

### DIFF
--- a/segment-root.go
+++ b/segment-root.go
@@ -4,7 +4,7 @@ import pwl "github.com/justjanne/powerline-go/powerline"
 
 func segmentRoot(p *powerline) []pwl.Segment {
 	var foreground, background uint8
-	if *p.args.PrevError == 0 {
+	if *p.args.PrevError == 0 || *p.args.StaticPromptIndicator {
 		foreground = p.theme.CmdPassedFg
 		background = p.theme.CmdPassedBg
 	} else {


### PR DESCRIPTION
### Possible fix for Issue #176

**Note:**
_StaticPromptIndicator_ only appears on newline prompt. Added condition for general root (on same line)

![with -static-prompt-indicator](https://user-images.githubusercontent.com/44697459/84891711-7f102880-b0c6-11ea-800c-4c98628db90e.png)
