### PR TITLE
fix hostname display when custom colors are set

### DIFF
--- a/segment-hostname.go
+++ b/segment-hostname.go
@@ -30,15 +30,15 @@ func segmentHost(p *powerline) []pwl.Segment {
 	}
 
 	if *p.args.ColorizeHostname {
+		hostName := getHostName(p.hostname)
+		hostPrompt = hostName
+
 		foregroundEnv, foregroundEnvErr := strconv.ParseInt(os.Getenv("PLGO_HOSTNAMEFG"), 0, 8)
 		backgroundEnv, backgroundEnvErr := strconv.ParseInt(os.Getenv("PLGO_HOSTNAMEBG"), 0, 8)
 		if foregroundEnvErr == nil && backgroundEnvErr == nil {
 			foreground = uint8(foregroundEnv)
 			background = uint8(backgroundEnv)
 		} else {
-			hostName := getHostName(p.hostname)
-			hostPrompt = hostName
-
 			hash := getMd5(hostName)
 			background = hash[0]
 			foreground = p.theme.HostnameColorizedFgMap[background]


### PR DESCRIPTION
When using custom colors with PLGO_HOSTNAMEFG and PLGO_HOSTNAMEBG, the hostname segment always displays an empty string, because `hostPrompt` is not set. This patch moves the hostPrompt assignment up one level to cover both of the code paths that handle color.