### PR TITLE
Suppress empty lines in prompt

### DIFF
--- a/powerline.go
+++ b/powerline.go
@@ -29,21 +29,21 @@ type ShellInfo struct {
 }
 
 type powerline struct {
-	args            args
-	cwd             string
-	userInfo        user.User
-	hostname        string
-	username        string
-	pathAliases     map[string]string
-	theme           Theme
-	shellInfo       ShellInfo
-	reset           string
-	symbolTemplates Symbols
-	priorities      map[string]int
-	ignoreRepos     map[string]bool
-	Segments        [][]pwl.Segment
-	curSegment      int
-	align           alignment
+	args                   args
+	cwd                    string
+	userInfo               user.User
+	hostname               string
+	username               string
+	pathAliases            map[string]string
+	theme                  Theme
+	shellInfo              ShellInfo
+	reset                  string
+	symbolTemplates        Symbols
+	priorities             map[string]int
+	ignoreRepos            map[string]bool
+	Segments               [][]pwl.Segment
+	curSegment             int
+	align                  alignment
 	rightPowerline         *powerline
 	appendEastAsianPadding int
 }
@@ -190,8 +190,10 @@ func (p *powerline) appendSegment(origin string, segment pwl.Segment) {
 }
 
 func (p *powerline) newRow() {
-	p.Segments = append(p.Segments, make([]pwl.Segment, 0))
-	p.curSegment = p.curSegment + 1
+	if len(p.Segments[p.curSegment]) > 0 {
+		p.Segments = append(p.Segments, make([]pwl.Segment, 0))
+		p.curSegment = p.curSegment + 1
+	}
 }
 
 func termWidth() int {


### PR DESCRIPTION
Modifies `newRow()` to only add a newline if there is content on the current line.

This allows prompts to collapse when lines are empty. 

To illustrate, I like to have **git** status on a line by itself, using this series of modules:
> newline,venv,user,host,newline,ssh,cwd,perms,newline,git,newline,exit,root

But, this shows a blank line when outside a git repo; collapsing the blank line keeps things tidy.

Within a git repo:
``` 
bevan > BEARPS-LAPTOP >
~ > go > src > github > theunrepentantgeek > powerline-go >
> improve/suppress-empty-lines > 2+ >
$ >
```
Up one level, outside the repo:
```
bevan > BEARPS-LAPTOP >
~ > go > src > github > theunrepentantgeek >
$ >
```
