### PR TITLE
Add rbenv segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,11 +220,11 @@ Usage of powerline-go:
     	 (default "patched")
   -modules string
     	 The list of modules to load, separated by ','
-    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
+    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
     	 (default "venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root")
   -modules-right string
     	 The list of modules to load anchored to the right, for shells that support it, separated by ','
-    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
+    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
   -newline
     	 Show the prompt on a new line
   -numeric-exit-codes
@@ -236,7 +236,7 @@ Usage of powerline-go:
     	 Use '~' for your home dir. You may need to escape this character to avoid shell substitution.
   -priority string
     	 Segments sorted by priority, if not enough space exists, the least priorized segments are removed first. Separate with ','
-    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
+    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
     	 (default "root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit,cwd-path")
   -shell string
     	 Set this to your shell type

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ var modules = map[string]func(*powerline) []pwl.Segment{
 	"perlbrew":            segmentPerlbrew,
 	"plenv":               segmentPlEnv,
 	"perms":               segmentPerms,
+	"rbenv":               segmentRbenv,
 	"root":                segmentRoot,
 	"shell-var":           segmentShellVar,
 	"shenv":               segmentShEnv,

--- a/segment-rbenv.go
+++ b/segment-rbenv.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	pwl "github.com/justjanne/powerline-go/powerline"
+	"os/exec"
+	"strings"
+)
+
+func runRbenvCommand(cmd string, args ...string) (string, error) {
+	command := exec.Command(cmd, args...)
+	out, err := command.Output()
+	return string(out), err
+}
+
+func segmentRbenv(p *powerline) []pwl.Segment {
+	out, err := runRbenvCommand("rbenv", "version")
+	
+	if err == nil {
+		items := strings.Split(out, " ")
+		if len(items) > 1 {
+			return []pwl.Segment{{
+				Name:       "rbenv",
+				Content:    items[0],
+				Foreground: p.theme.TimeFg,
+				Background: p.theme.TimeBg,
+			}}	
+		}
+	}
+
+	return []pwl.Segment{}
+}


### PR DESCRIPTION
I'm using Ruby (through it's version manager [rbenv](https://github.com/rbenv/rbenv)) a lot at work and love to get support into powerline-go. This segment displays the currently activated ruby version which is very useful when you often switch between projects that are using a different ruby version.

Since my go is a bit rusty please point me to enhancements that can be added to the PR (I'm not 100% if I got the error handling 100% right).

You can try this segment by calling:

```sh
eval powerline-go -error $status -shell bare -modules rbenv,venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root
```