### PR TITLE
typo in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Usage of powerline-go:
     	 (valid choices: default, low-contrast)
     	 (default "default")
   -truncate-segment-width int
-    	 Minimum width of a segment, segments longer than this will be shortened if space is limited. Setting this to 0 disables it.
+    	 Maximum width of a segment, segments longer than this will be shortened if space is limited. Setting this to 0 disables it.
     	 (default 16)
 ```
 

--- a/main.go
+++ b/main.go
@@ -216,7 +216,7 @@ func main() {
 		TruncateSegmentWidth: flag.Int(
 			"truncate-segment-width",
 			16,
-			commentsWithDefaults("Minimum width of a segment, segments longer than this will be shortened if space is limited. Setting this to 0 disables it.")),
+			commentsWithDefaults("Maximum width of a segment, segments longer than this will be shortened if space is limited. Setting this to 0 disables it.")),
 		PrevError: flag.Int(
 			"error",
 			0,


### PR DESCRIPTION
in truncate-segment-width explanation