### PR TITLE
parse environment variables to uint

### DIFF
--- a/segment-hostname.go
+++ b/segment-hostname.go
@@ -33,8 +33,8 @@ func segmentHost(p *powerline) []pwl.Segment {
 		hostName := getHostName(p.hostname)
 		hostPrompt = hostName
 
-		foregroundEnv, foregroundEnvErr := strconv.ParseInt(os.Getenv("PLGO_HOSTNAMEFG"), 0, 8)
-		backgroundEnv, backgroundEnvErr := strconv.ParseInt(os.Getenv("PLGO_HOSTNAMEBG"), 0, 8)
+		foregroundEnv, foregroundEnvErr := strconv.ParseUint(os.Getenv("PLGO_HOSTNAMEFG"), 0, 8)
+		backgroundEnv, backgroundEnvErr := strconv.ParseUint(os.Getenv("PLGO_HOSTNAMEBG"), 0, 8)
 		if foregroundEnvErr == nil && backgroundEnvErr == nil {
 			foreground = uint8(foregroundEnv)
 			background = uint8(backgroundEnv)


### PR DESCRIPTION
Makes powerline-go always treat color values from environment variables as `uint8`.

Currently, the variables are parsed as `int8`, and then cast to `uint8`, which makes handling reddish colors problematic.