### PR TITLE
fix logic error for east asian width

### DIFF
--- a/powerline.go
+++ b/powerline.go
@@ -284,7 +284,7 @@ func (p *powerline) truncateRow(rowNum int) {
 }
 
 func (p *powerline) numEastAsianRunes(segmentContent *string) int {
-	if *p.args.EastAsianWidth {
+	if !*p.args.EastAsianWidth {
 		return 0
 	}
 	numEastAsianRunes := 0


### PR DESCRIPTION
Closes #244 

Fixes some logical error relating to #205

Adding extra space should be only when -east-asian-width flag is present. There is a logical error that it adds extra space when the -east-asian-width flag is not present instead.