### PR TITLE
Added cwd-mode 'semifancy' and git-mode 'simple'

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Usage of powerline-go:
     	 (default -1)
   -cwd-mode string
     	 How to display the current directory
-    	 (valid choices: fancy, plain, dironly)
+    	 (valid choices: fancy, semifancy, plain, dironly)
     	 (default "fancy")
   -duration string
     	 The elapsed clock-time of the previous command
@@ -211,6 +211,10 @@ Usage of powerline-go:
   -git-disable-stats string
     	 Comma-separated list to disable individual git statuses
     	 (valid choices: ahead, behind, staged, notStaged, untracked, conflicted, stashed)
+  -git-mode string
+    	 How to display git status
+    	 (valid choices: fancy, simple)
+    	 (default "fancy")
   -hostname-only-if-ssh
     	 Show hostname only for SSH connections
   -ignore-repos string

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ type args struct {
 	StaticPromptIndicator  *bool
 	GitAssumeUnchangedSize *int64
 	GitDisableStats        *string
+	GitMode                *string
 	Mode                   *string
 	Theme                  *string
 	Shell                  *string
@@ -147,7 +148,7 @@ func main() {
 			"cwd-mode",
 			"fancy",
 			commentsWithDefaults("How to display the current directory",
-				"(valid choices: fancy, plain, dironly)")),
+				"(valid choices: fancy, semifancy, plain, dironly)")),
 		CwdMaxDepth: flag.Int(
 			"cwd-max-depth",
 			5,
@@ -189,6 +190,11 @@ func main() {
 			"",
 			commentsWithDefaults("Comma-separated list to disable individual git statuses",
 				"(valid choices: ahead, behind, staged, notStaged, untracked, conflicted, stashed)")),
+		GitMode: flag.String(
+			"git-mode",
+			"fancy",
+			commentsWithDefaults("How to display git status",
+				"(valid choices: fancy, simple)")),
 		Mode: flag.String(
 			"mode",
 			"patched",

--- a/segment-cwd.go
+++ b/segment-cwd.go
@@ -199,6 +199,27 @@ func segmentCwd(p *powerline) (segments []pwl.Segment) {
 				})
 				pathSegments = append(pathSegments, secondPart...)
 			}
+
+			if *p.args.CwdMode == "semifancy" && len(pathSegments) > 1 {
+				var path string
+				for idx, pathSegment := range pathSegments {
+					if pathSegment.home || pathSegment.alias {
+						continue
+					}
+					path += pathSegment.path
+					if idx != len(pathSegments)-1 {
+						path += string(os.PathSeparator)
+					}
+				}
+				first := pathSegments[0]
+				pathSegments = make([]pathSegment, 0)
+				if (first.home || first.alias) {
+					pathSegments = append(pathSegments, first)
+				}
+				pathSegments = append(pathSegments, pathSegment{
+					path:	  path,
+				})
+			}
 		}
 
 		for idx, pathSegment := range pathSegments {

--- a/segment-git.go
+++ b/segment-git.go
@@ -25,6 +25,10 @@ func (r repoStats) dirty() bool {
 	return r.untracked+r.notStaged+r.staged+r.conflicted > 0
 }
 
+func (r repoStats) any() bool {
+	return r.ahead+r.behind+r.untracked+r.notStaged+r.staged+r.conflicted+r.stashed > 0
+}
+
 func addRepoStatsSegment(nChanges int, symbol string, foreground uint8, background uint8) []pwl.Segment {
 	if nChanges > 0 {
 		return []pwl.Segment{{
@@ -66,6 +70,25 @@ func (r repoStats) GitSegments(p *powerline) (segments []pwl.Segment) {
 	segments = append(segments, addRepoStatsSegment(r.conflicted, p.symbolTemplates.RepoConflicted, p.theme.GitConflictedFg, p.theme.GitConflictedBg)...)
 	segments = append(segments, addRepoStatsSegment(r.stashed, p.symbolTemplates.RepoStashed, p.theme.GitStashedFg, p.theme.GitStashedBg)...)
 	return
+}
+
+func addRepoStatsSymbol(nChanges int, symbol string) string {
+	if nChanges > 0 {
+		return symbol
+	}
+	return ""
+}
+
+func (r repoStats) GitSymbols(p *powerline) string {
+	var info string
+	info += addRepoStatsSymbol(r.ahead, p.symbolTemplates.RepoAhead)
+	info += addRepoStatsSymbol(r.behind, p.symbolTemplates.RepoBehind)
+	info += addRepoStatsSymbol(r.staged, p.symbolTemplates.RepoStaged)
+	info += addRepoStatsSymbol(r.notStaged, p.symbolTemplates.RepoNotStaged)
+	info += addRepoStatsSymbol(r.untracked, p.symbolTemplates.RepoUntracked)
+	info += addRepoStatsSymbol(r.conflicted, p.symbolTemplates.RepoConflicted)
+	info += addRepoStatsSymbol(r.stashed, p.symbolTemplates.RepoStashed)
+	return info
 }
 
 var branchRegex = regexp.MustCompile(`^## (?P<local>\S+?)(\.{3}(?P<remote>\S+?)( \[(ahead (?P<ahead>\d+)(, )?)?(behind (?P<behind>\d+))?])?)?$`)
@@ -230,6 +253,14 @@ func segmentGit(p *powerline) []pwl.Segment {
 		Foreground: foreground,
 		Background: background,
 	}}
-	segments = append(segments, stats.GitSegments(p)...)
+
+	if *p.args.GitMode == "simple" {
+		if stats.any() {
+			segments[0].Content += " " + stats.GitSymbols(p)
+		}
+	} else { // fancy
+		segments = append(segments, stats.GitSegments(p)...)
+	}
+
 	return segments
 }


### PR DESCRIPTION
In an effort to conserve some horizontal space I have added two new modes.

cwd-mode 'semifancy' is halfway between fancy and plain. It retains path aliasing and ellipses, but puts the cwd in a single segment.
Similarly, git-mode 'simple' is less than fancy, but a bit more than gitlite. It condenses the stats into the branch segment, and only displays their symbols.

Here you can see both:
![image](https://user-images.githubusercontent.com/12523019/97809433-70b84880-1c32-11eb-8169-53d5cf1697c3.png)
