### PR TITLE
add new flag -show-warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Usage of powerline-go:
     	 Shortens names for EKS Kube clusters.
   -shorten-gke-names
     	 Shortens names for GKE Kube clusters.
+  -show-warnings
+         Warning messages will be printed to stdout
   -static-prompt-indicator
     	 Always show the prompt indicator with the default color, never with the error color
   -theme string


### PR DESCRIPTION
This flag could be used to toggle all warn-messages which are prompted
to stdout.

For example: if you use -shell-var flag and some variables aren't always
set (as expected) you will always see (for a very short time) the
prompt, that the variable isn't set. In combination with
-show-warnings=false your eyes are spared and you can be much more
focused on doing command line stuff ;-)

Signed-off-by: Mario Constanti <github@constanti.de>