### PR TITLE
Add arg to suppress warning for empty shell var

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Usage of powerline-go:
     	 (default "bash")
   -shell-var string
     	 A shell variable to add to the segments.
+  -shell-var-no-warn-empty
+    	 Disables warning for empty shell variable.
   -shorten-eks-names
     	 Shortens names for EKS Kube clusters.
   -shorten-gke-names

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ type args struct {
 	ShortenGKENames        *bool
 	ShortenEKSNames        *bool
 	ShellVar               *string
+	ShellVarNoWarnEmpty    *bool
 	TrimADDomain           *bool
 	PathAliases            *string
 	Duration               *string
@@ -244,6 +245,10 @@ func main() {
 			"shell-var",
 			"",
 			comments("A shell variable to add to the segments.")),
+		ShellVarNoWarnEmpty: flag.Bool(
+			"shell-var-no-warn-empty",
+			false,
+			comments("Disables warning for empty shell variable.")),
 		TrimADDomain: flag.Bool(
 			"trim-ad-domain",
 			false,

--- a/segment-shellvar.go
+++ b/segment-shellvar.go
@@ -18,8 +18,9 @@ func segmentShellVar(p *powerline) []pwl.Segment {
 				Background: p.theme.ShellVarBg,
 			}}
 		}
-		warn("Shell variable " + shellVarName + " is empty.")
-
+		if !*p.args.ShellVarNoWarnEmpty {
+			warn("Shell variable " + shellVarName + " is empty.")
+		}
 	} else {
 		warn("Shell variable " + shellVarName + " does not exist.")
 	}


### PR DESCRIPTION
There were some discussions around this in the original pull request https://github.com/justjanne/powerline-go/pull/60#issuecomment-352285175 as to when and how to warn. Decided to go with a command line argument but if anyone has any strong opinions I can certainly adjust.