### PR TITLE
Add goenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,11 +221,11 @@ Usage of powerline-go:
     	 (default "patched")
   -modules string
     	 The list of modules to load, separated by ','
-    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
+    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
     	 (default "venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root")
   -modules-right string
     	 The list of modules to load anchored to the right, for shells that support it, separated by ','
-    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
+    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
   -newline
     	 Show the prompt on a new line
   -numeric-exit-codes
@@ -237,7 +237,7 @@ Usage of powerline-go:
     	 Use '~' for your home dir. You may need to escape this character to avoid shell substitution.
   -priority string
     	 Segments sorted by priority, if not enough space exists, the least priorized segments are removed first. Separate with ','
-    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
+    	 (valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)
     	 (default "root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit,cwd-path")
   -shell string
     	 Set this to your shell type

--- a/defaults.go
+++ b/defaults.go
@@ -158,6 +158,9 @@ var themes = map[string]Theme{
 		GitStashedFg:    15,
 		GitStashedBg:    20,
 
+		GoenvBg: 38,  // approx. Gopher Blue
+		GoenvFg: 220, // approx. Secondary Yellow
+
 		VirtualEnvFg: 00,
 		VirtualEnvBg: 35, // a mid-tone green
 
@@ -527,6 +530,9 @@ var themes = map[string]Theme{
 		GitStashedFg:    15,
 		GitStashedBg:    20,
 
+		GoenvBg: 38,  // approx. Gopher Blue
+		GoenvFg: 220, // approx. Secondary Yellow
+
 		VirtualEnvFg: 35, // a mid-tone green
 		VirtualEnvBg: 254,
 
@@ -863,6 +869,8 @@ var themes = map[string]Theme{
 		GitConflictedBg:    1,
 		GitStashedFg:       15,
 		GitStashedBg:       4,
+		GoenvBg:            38,  // approx. Gopher Blue
+		GoenvFg:            220, // approx. Secondary Yellow
 		VirtualEnvFg:       8,
 		VirtualEnvBg:       6,
 		PerlbrewFg:         8,
@@ -1193,6 +1201,8 @@ var themes = map[string]Theme{
 		GitConflictedBg:    1,
 		GitStashedFg:       15,
 		GitStashedBg:       4,
+		GoenvBg:            38,  // approx. Gopher Blue
+		GoenvFg:            220, // approx. Secondary Yellow
 		VirtualEnvFg:       8,
 		VirtualEnvBg:       6,
 		PerlbrewFg:         8,
@@ -1524,6 +1534,8 @@ var themes = map[string]Theme{
 		GitConflictedBg:    gruvbox_neutral_red,
 		GitStashedFg:       gruvbox_dark0,
 		GitStashedBg:       gruvbox_neutral_yellow,
+		GoenvBg:            gruvbox_faded_blue,
+		GoenvFg:            gruvbox_light1,
 		VirtualEnvFg:       gruvbox_light0,
 		VirtualEnvBg:       gruvbox_faded_green,
 		PerlbrewFg:         gruvbox_light0,  // match virtualenv

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ var modules = map[string]func(*powerline) []pwl.Segment{
 	"gcp":                 segmentGCP,
 	"git":                 segmentGit,
 	"gitlite":             segmentGitLite,
+	"goenv":               segmentGoenv,
 	"hg":                  segmentHg,
 	"svn":                 segmentSubversion,
 	"host":                segmentHost,
@@ -200,12 +201,12 @@ func main() {
 			"modules",
 			"venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root",
 			commentsWithDefaults("The list of modules to load, separated by ','",
-				"(valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)")),
+				"(valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)")),
 		ModulesRight: flag.String(
 			"modules-right",
 			"",
 			comments("The list of modules to load anchored to the right, for shells that support it, separated by ','",
-				"(valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)")),
+				"(valid choices: aws, cwd, docker, docker-context, dotenv, duration, exit, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, root, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo)")),
 		Priority: flag.String(
 			"priority",
 			"root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit,cwd-path",

--- a/segment-goenv.go
+++ b/segment-goenv.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	pwl "github.com/justjanne/powerline-go/powerline"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const goenvVersionFileSuffix = "/.go-version"
+const goenvVersionEnvVar = "GOENV_VERSION"
+const goenvGlobalVersionFileSuffix = "/.goenv/version"
+
+func runGoenvCommand(cmd string, args ...string) (string, error) {
+	command := exec.Command(cmd, args...)
+	out, err := command.Output()
+	return string(out), err
+}
+
+// check GOENV_VERSION variable
+func checkEnvForGoenvVersion() (string, error) {
+	goenvVersion := os.Getenv(goenvVersionEnvVar)
+	if len(goenvVersion) > 0 {
+		return goenvVersion, nil
+	} else {
+		return "", fmt.Errorf("Not found in %s", goenvVersionEnvVar)
+	}
+}
+
+// check existence of .go-version in tree until root path
+func checkForGoVersionFileInTree() (string, error) {
+	var (
+		workingDirectory string
+		err              error
+	)
+
+	workingDirectory, err = os.Getwd()
+	if err == nil {
+		for workingDirectory != "/" {
+			goVersion, goVersionErr := ioutil.ReadFile(workingDirectory + goenvVersionFileSuffix)
+			if goVersionErr == nil {
+				return strings.TrimSpace(string(goVersion)), nil
+			}
+
+			workingDirectory = filepath.Dir(workingDirectory)
+		}
+	}
+
+	return "", fmt.Errorf("No %s file found in tree", goenvVersionFileSuffix)
+}
+
+// check for global version
+func checkForGoenvGlobalVersion() (string, error) {
+	homeDir, _ := os.UserHomeDir()
+	globalGoVersion, err := ioutil.ReadFile(homeDir + goenvGlobalVersionFileSuffix)
+	if err == nil {
+		return strings.TrimSpace(string(globalGoVersion)), nil
+	} else {
+		return "", fmt.Errorf("No global go version file found in %s", homeDir+goenvGlobalVersionFileSuffix)
+	}
+}
+
+// retrieve goenv version output
+func checkForGoenvOutput() (string, error) {
+	// spawn goenv and print out version
+	out, err := runGoenvCommand("goenv", "version")
+	if err == nil {
+		items := strings.Split(out, " ")
+		if len(items) > 1 {
+			return items[0], nil
+		}
+	}
+
+	return "", fmt.Errorf("Not found in goenv object")
+}
+
+func segmentGoenv(p *powerline) []pwl.Segment {
+	var (
+		segment string
+		err     error
+	)
+
+	segment, err = checkEnvForGoenvVersion()
+	if err != nil {
+		segment, err = checkForGoVersionFileInTree()
+	}
+	if err != nil {
+		segment, err = checkForGoenvGlobalVersion()
+	}
+	if err != nil {
+		segment, err = checkForGoenvOutput()
+	}
+	if err != nil {
+		return []pwl.Segment{}
+	} else {
+		return []pwl.Segment{{
+			Name:       "goenv",
+			Content:    segment,
+			Foreground: p.theme.GoenvFg,
+			Background: p.theme.GoenvBg,
+		}}
+	}
+}

--- a/themes.go
+++ b/themes.go
@@ -103,6 +103,9 @@ type Theme struct {
 	GitStashedFg    uint8
 	GitStashedBg    uint8
 
+	GoenvFg uint8
+	GoenvBg uint8
+
 	VirtualEnvFg uint8
 	VirtualEnvBg uint8
 


### PR DESCRIPTION
Copies and slightly modifies the existing `rbenv` plugin to support `goenv`. Notably, attempts to follow the Go branding guide when selecting theme colors.

The primary difference between this and #259 is that because it is following essentially the same logic as rbenv, it checks for go versions that aren't set in the shell (ie. `GOENV_VERSION` or `goenv shell <version>`).