### PR TITLE
add go version for test jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ os: linux
 dist: xenial
 
 go:
+  - "1.12"
+  - "1.13"
   - "1.14"
+  - "1.15"
 
 # before we deploy, we go build for all operating systems we would like to support
 before_deploy:


### PR DESCRIPTION
Add additional test job to test for multiple go version (1.12 - 1.15). This will help ensure the project supports a broader range of go versions.