### PR TITLE
Use goenv's colors for vgo too

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -233,8 +233,8 @@ var defaults = Config{
 			VirtualEnvFg: 00,
 			VirtualEnvBg: 35, // a mid-tone green
 
-			VirtualGoFg: 00,
-			VirtualGoBg: 35,
+			VirtualGoFg: 220, // approx. Secondary Yellow
+			VirtualGoBg: 38,  // approx. Gopher Blue
 
 			PerlbrewFg: 00,
 			PerlbrewBg: 20, // a mid-tone blue
@@ -605,8 +605,8 @@ var defaults = Config{
 			VirtualEnvFg: 35, // a mid-tone green
 			VirtualEnvBg: 254,
 
-			VirtualGoFg: 35,
-			VirtualGoBg: 254,
+			VirtualGoFg: 220, // approx. Secondary Yellow
+			VirtualGoBg: 38,  // approx. Gopher Blue
 
 			PerlbrewFg: 20, // a mid-tone blue
 			PerlbrewBg: 15,


### PR DESCRIPTION
A continuation of #260, not that I actually have ever used vgo myself, but it seems more work in determining the right colors has been done for goenv rather than here and they're more official golang ones, so makes sense to use them. I'm assuming not many use both vgo and goenv simultaneously.