### PR TITLE
DOC: Extend list of valid theme choices in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Usage of powerline-go:
          Always show the prompt indicator with the default color, never with the error color
   -theme string
          Set this to the theme you want to use
-         (valid choices: default, low-contrast)
+         (valid choices: default, low-contrast, gruvbox, solarized-dark16, solarized-light16)
          (default "default")
   -trim-ad-domain
          Trim the Domainname from the AD username.


### PR DESCRIPTION
This adds other themes to the list of valid theme options. These are currently missing in the README file.