### PR TITLE
Fix -max-width argument to re-enable prompt shrinking

### DIFF
--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func main() {
 			cfg.ModulesRight = strings.Split(*args.ModulesRight, ",")
 		case "priority":
 			cfg.Priority = strings.Split(*args.Priority, ",")
-		case "max-width-percentage":
+		case "max-width":
 			cfg.MaxWidthPercentage = *args.MaxWidthPercentage
 		case "truncate-segment-width":
 			cfg.TruncateSegmentWidth = *args.TruncateSegmentWidth


### PR DESCRIPTION
## Relevant Issue

This closes #279!

## The Problem

For context, when #251 added support for a JSON config file, the logic for merging the JSON config with passed arguments was implemented in a switch statement in the main function in `main.go`. However, the name for the `-max-width` flag was incorrectly entered here as `-max-width-percentage`.

As a result, setting the argument `-max-width [nonzero number]` would do nothing. In particular, the automatic truncation and elimination of low-priority segments would no longer trigger, even when the row length was extremely long. (On the other hand, it seems the JSON config option does work as intended. In order to reproduce this issue, remember to remove any JSON config at `~/.config/powerline-go/config.json`.)

## The Solution

Simply replace the `max-width-percentage` in the switch statement with `max-width`. Now I can enjoy my absurdly skinny terminals and my ridiculously long branch names with the comfort of powerline-go!
