### PR TITLE
git ignores global config gitexcludes/.git/config/ignore #295

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -1,0 +1,11 @@
+package main
+
+import "runtime"
+
+func homeEnvName() string {
+	env := "HOME"
+	if runtime.GOOS == "windows" {
+		env = "USERPROFILE"
+	}
+	return env
+}

--- a/segment-git.go
+++ b/segment-git.go
@@ -88,14 +88,15 @@ func groupDict(pattern *regexp.Regexp, haystack string) map[string]string {
 }
 
 var gitProcessEnv = func() []string {
-	home, _ := os.LookupEnv("HOME")
+	homeEnv := homeEnvName()
+	home, _ := os.LookupEnv(homeEnv)
 	path, _ := os.LookupEnv("PATH")
 	env := map[string]string{
-		"LANG": "C",
-		"HOME": home,
-		"PATH": path,
+		"LANG":  "C",
+		homeEnv: home,
+		"PATH":  path,
 	}
-	result := make([]string, len(env))
+	result := make([]string, 0)
 	for key, value := range env {
 		result = append(result, fmt.Sprintf("%s=%s", key, value))
 	}

--- a/segment-kube.go
+++ b/segment-kube.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -31,11 +30,7 @@ type KubeConfig struct {
 }
 
 func homePath() string {
-	env := "HOME"
-	if runtime.GOOS == "windows" {
-		env = "USERPROFILE"
-	}
-	return os.Getenv(env)
+	return os.Getenv(homeEnvName())
 }
 
 func readKubeConfig(config *KubeConfig, path string) (err error) {


### PR DESCRIPTION
This fixes #295 for me. The main culprit was the init `make([]string, len(env))` which added 3 zero entries to the slice which broke HOME/USERPROFILE for git status. Used USERPROFILE hack from segement-kube for windows in this case as well, as HOME is not set in gitbash/windows.

I did not find any suitable file for homeEnvName() so i added a new environment.go.