### PR TITLE
Path should be escaped in plain mode

### DIFF
--- a/segment-cwd.go
+++ b/segment-cwd.go
@@ -169,7 +169,7 @@ func segmentCwd(p *powerline) (segments []pwl.Segment) {
 
 		segments = append(segments, pwl.Segment{
 			Name:       "cwd",
-			Content:    cwd,
+			Content:    escapeVariables(p, cwd),
 			Foreground: p.theme.CwdFg,
 			Background: p.theme.PathBg,
 		})


### PR DESCRIPTION
Closes  #297

Fixes path on "plain" mode is not escaped, which cause prints to stdout to be messed up.