### PR TITLE
feat(duration): add low precision duration setting

### DIFF
--- a/args.go
+++ b/args.go
@@ -39,6 +39,7 @@ type arguments struct {
 	PathAliases            *string
 	Duration               *string
 	DurationMin            *string
+	DurationLowPrecision   *bool
 	Eval                   *bool
 	Condensed              *bool
 	IgnoreWarnings         *bool
@@ -192,6 +193,10 @@ var args = arguments{
 		"duration-min",
 		defaults.DurationMin,
 		comments("The minimal time a command has to take before the duration segment is shown")),
+	DurationLowPrecision: flag.Bool(
+		"duration-low-precision",
+		defaults.DurationLowPrecision,
+		comments("Use low precision timing for duration with milliseconds as maximum resolution")),
 	Eval: flag.Bool(
 		"eval",
 		defaults.Eval,

--- a/config.go
+++ b/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	PathAliases            AliasMap  `json:"path-aliases"`
 	Duration               string    `json:"-"`
 	DurationMin            string    `json:"duration-min"`
+	DurationLowPrecision   bool      `json:"duration-low-precision"`
 	Eval                   bool      `json:"eval"`
 	Condensed              bool      `json:"condensed"`
 	IgnoreWarnings         bool      `json:"ignore-warnings"`

--- a/defaults.go
+++ b/defaults.go
@@ -59,6 +59,7 @@ var defaults = Config{
 	PathAliases:          AliasMap{},
 	Duration:             "",
 	DurationMin:          "0",
+	DurationLowPrecision: false,
 	Eval:                 false,
 	Condensed:            false,
 	IgnoreWarnings:       false,

--- a/main.go
+++ b/main.go
@@ -198,6 +198,8 @@ func main() {
 			cfg.Duration = *args.Duration
 		case "duration-min":
 			cfg.DurationMin = *args.DurationMin
+		case "duration-low-precision":
+			cfg.DurationLowPrecision = *args.DurationLowPrecision
 		case "eval":
 			cfg.Eval = *args.Eval
 		case "condensed":

--- a/segment-duration.go
+++ b/segment-duration.go
@@ -82,11 +82,15 @@ func segmentDuration(p *powerline) []pwl.Segment {
 		ns -= secs * seconds
 		millis := ns / milliseconds
 		content = fmt.Sprintf("%ds %dms", secs, millis)
-	} else if ns > milliseconds {
+	} else if ns > milliseconds || p.cfg.DurationLowPrecision {
 		millis := ns / milliseconds
 		ns -= millis * milliseconds
 		micros := ns / microseconds
-		content = fmt.Sprintf("%dms %d\u00B5s", millis, micros)
+		if p.cfg.DurationLowPrecision {
+			content = fmt.Sprintf("%dms", millis)
+		} else {
+			content = fmt.Sprintf("%dms %d\u00B5s", millis, micros)
+		}
 	} else {
 		content = fmt.Sprintf("%d\u00B5s", ns/microseconds)
 	}


### PR DESCRIPTION
This brings in a new command line flag `-duration-low-precision` that
can be used to disable showing µs in the duration segment. This is
needed for shells like `fish` that only have millisecond precision or
for when people decide that they just don't want to have that extreme
level of precision.

Contributes to justjanne/powerline-go#307

DCO-1.1-Signed-off-by: Patrick Wagstrom <patrick@wagstrom.net>