### PR TITLE
Restyle nix-shell segment

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -264,7 +264,7 @@ var defaults = Config{
 			LoadAvgValue:     5,
 			LoadThresholdBad: 1.0,
 
-			NixShellFg: 00,
+			NixShellFg: 15,
 			NixShellBg: 69, // a light blue
 
 			DurationFg: 250,

--- a/segment-nix-shell.go
+++ b/segment-nix-shell.go
@@ -13,7 +13,7 @@ func segmentNixShell(p *powerline) []pwl.Segment {
 	}
 	return []pwl.Segment{{
 		Name:       "nix-shell",
-		Content:    nixShell,
+		Content:    "\uf313",
 		Foreground: p.theme.NixShellFg,
 		Background: p.theme.NixShellBg,
 	}}

--- a/themes/default.json
+++ b/themes/default.json
@@ -69,7 +69,7 @@
   "LoadHighBg": 161,
   "LoadAvgValue": 5,
   "LoadThresholdBad": 1.0,
-  "NixShellFg": 0,
+  "NixShellFg": 15,
   "NixShellBg": 69,
   "DurationFg": 250,
   "DurationBg": 237,


### PR DESCRIPTION
This is a patch that I (and some friends) have been locally running, that I think makes the `nix` segment nicer to use.

Before:
![nix-shell-before](https://user-images.githubusercontent.com/3593851/116489570-3f15f680-a8d0-11eb-9ace-defcc6be267b.png)

After:
![nix-shell-after](https://user-images.githubusercontent.com/3593851/116489579-43daaa80-a8d0-11eb-9ea8-9c6c9cb73e69.png)

Having just the logo instead of the text should be fine because
  - You rarely care about whether you're in a pure/impure shell
  - If like most nix users you're in nix-shells a lot it's an annoyingly long segment

I also changed the color to more closely match the blue/white nix colors