### PR TITLE
only warn about shellVarName not existing if it's been set

### DIFF
--- a/segment-shellvar.go
+++ b/segment-shellvar.go
@@ -11,7 +11,9 @@ func segmentShellVar(p *powerline) []pwl.Segment {
 	varContent, varExists := os.LookupEnv(shellVarName)
 
 	if !varExists {
-		warn("Shell variable " + shellVarName + " does not exist.")
+		if shellVarName != "" {
+			warn("Shell variable " + shellVarName + " does not exist.")
+		}
 		return []pwl.Segment{}
 	}
 


### PR DESCRIPTION
For the shell-var module to be optionally used (defined in -modules to reserve its placement), can we warn about it not existing only if -shell-var has actually been specified ?

"`Shell variable__does not exist.`" is awfully vague anyways.  ("_" added to emphasis blank spacing)
