### PR TITLE
Add support to show current date and time

### DIFF
--- a/args.go
+++ b/args.go
@@ -42,6 +42,7 @@ type arguments struct {
 	Eval                   *bool
 	Condensed              *bool
 	IgnoreWarnings         *bool
+	Time                   *string
 }
 
 var args = arguments{
@@ -187,6 +188,10 @@ var args = arguments{
 	Duration: flag.String(
 		"duration",
 		defaults.Duration,
+		comments("The elapsed clock-time of the previous command")),
+	Time: flag.String(
+		"time",
+		defaults.Time,
 		comments("The elapsed clock-time of the previous command")),
 	DurationMin: flag.String(
 		"duration-min",

--- a/args.go
+++ b/args.go
@@ -192,7 +192,9 @@ var args = arguments{
 	Time: flag.String(
 		"time",
 		defaults.Time,
-		comments("The elapsed clock-time of the previous command")),
+		comments("The layout string how a reference time should be represented.",
+			"The reference time is predefined and not user choosen.",
+			"Consult the golang documentation for details: https://pkg.go.dev/time#example-Time.Format")),
 	DurationMin: flag.String(
 		"duration-min",
 		defaults.DurationMin,

--- a/config.go
+++ b/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	Modes                  SymbolMap `json:"modes"`
 	Shells                 ShellMap  `json:"shells"`
 	Themes                 ThemeMap  `json:"themes"`
+	Time                   string    `json:"-"`
 }
 
 func (mode *SymbolTemplate) UnmarshalJSON(data []byte) error {

--- a/defaults.go
+++ b/defaults.go
@@ -1626,6 +1626,7 @@ var defaults = Config{
 			NixShellBg:         gruvbox_faded_purple,
 		},
 	},
+	Time:                 "15:04:05",
 }
 
 const (

--- a/main.go
+++ b/main.go
@@ -200,6 +200,8 @@ func main() {
 			cfg.Condensed = *args.Condensed
 		case "ignore-warnings":
 			cfg.IgnoreWarnings = *args.IgnoreWarnings
+		case "time":
+			cfg.Time = *args.Time
 		}
 	})
 

--- a/segment-time.go
+++ b/segment-time.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	pwl "github.com/justjanne/powerline-go/powerline"
 	"time"
 )
@@ -8,7 +9,7 @@ import (
 func segmentTime(p *powerline) []pwl.Segment {
 	return []pwl.Segment{{
 		Name:       "time",
-		Content:    time.Now().Format("15:04:05"),
+		Content:    time.Now().Format(strings.TrimSpace(p.cfg.Time)),
 		Foreground: p.theme.TimeFg,
 		Background: p.theme.TimeBg,
 	}}


### PR DESCRIPTION
Fixes #238

This allows to give a time layout as argument. See details [Time.Format](https://pkg.go.dev/time#Time.Format)

```shell
function _update_ps1() {
    PS1="$(powerline-go -error $? -jobs $(jobs -p | wc -l) -newline -time '06-01-02 15:04:05' -modules time,cwd,exit,git,hg,host,jobs,perms,root,ssh,user,venv )"
}
```

If no argument given to time option it will use the default before this pull request.
