### PR TITLE
support custom Kubernetes cluster name shortening with regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ but you may have to set your $TERM to `xterm-256color` for it to work.
 If you want to use the "patched" mode (which is the default, and provides
 improved UI), you'll need to install a powerline font, either as fallback,
 or by patching the font you use for your terminal: see
-[powerline-fonts](https://github.com/Lokaltog/powerline-fonts).  
+[powerline-fonts](https://github.com/Lokaltog/powerline-fonts).
 Alternatively you can use "compatible" or "flat" mode.
 
 ### Precompiled Binaries
@@ -248,6 +248,10 @@ Usage of powerline-go:
     	 Shortens names for EKS Kube clusters.
   -shorten-gke-names
     	 Shortens names for GKE Kube clusters.
+  -shorten-kube-names-regex-match string
+    	 Shortens names for Kube clusters matching a custom regex.
+  -shorten-kube-names-regex-template string
+    	 String template to use with -shorten-kube-names-regex-match. (default "${1}")
   -static-prompt-indicator
     	 Always show the prompt indicator with the default color, never with the error color
   -theme string

--- a/main.go
+++ b/main.go
@@ -30,35 +30,37 @@ const (
 )
 
 type args struct {
-	CwdMode                *string
-	CwdMaxDepth            *int
-	CwdMaxDirSize          *int
-	ColorizeHostname       *bool
-	HostnameOnlyIfSSH      *bool
-	SshAlternateIcon       *bool
-	EastAsianWidth         *bool
-	PromptOnNewLine        *bool
-	StaticPromptIndicator  *bool
-	GitAssumeUnchangedSize *int64
-	Mode                   *string
-	Theme                  *string
-	Shell                  *string
-	Modules                *string
-	ModulesRight           *string
-	Priority               *string
-	MaxWidthPercentage     *int
-	TruncateSegmentWidth   *int
-	PrevError              *int
-	NumericExitCodes       *bool
-	IgnoreRepos            *string
-	ShortenGKENames        *bool
-	ShortenEKSNames        *bool
-	ShellVar               *string
-	PathAliases            *string
-	Duration               *string
-	DurationMin            *string
-	Eval                   *bool
-	Condensed              *bool
+	CwdMode                       *string
+	CwdMaxDepth                   *int
+	CwdMaxDirSize                 *int
+	ColorizeHostname              *bool
+	HostnameOnlyIfSSH             *bool
+	SshAlternateIcon              *bool
+	EastAsianWidth                *bool
+	PromptOnNewLine               *bool
+	StaticPromptIndicator         *bool
+	GitAssumeUnchangedSize        *int64
+	Mode                          *string
+	Theme                         *string
+	Shell                         *string
+	Modules                       *string
+	ModulesRight                  *string
+	Priority                      *string
+	MaxWidthPercentage            *int
+	TruncateSegmentWidth          *int
+	PrevError                     *int
+	NumericExitCodes              *bool
+	IgnoreRepos                   *string
+	ShortenGKENames               *bool
+	ShortenEKSNames               *bool
+	ShortenKubeNamesRegexMatch    *string
+	ShortenKubeNamesRegexTemplate *string
+	ShellVar                      *string
+	PathAliases                   *string
+	Duration                      *string
+	DurationMin                   *string
+	Eval                          *bool
+	Condensed                     *bool
 }
 
 func warn(msg string) {
@@ -238,6 +240,14 @@ func main() {
 			"shorten-eks-names",
 			false,
 			comments("Shortens names for EKS Kube clusters.")),
+		ShortenKubeNamesRegexMatch: flag.String(
+			"shorten-kube-names-regex-match",
+			"",
+			comments("Shortens names for Kube clusters matching a custom regex.")),
+		ShortenKubeNamesRegexTemplate: flag.String(
+			"shorten-kube-names-regex-template",
+			"${1}",
+			comments("String template to use with -shorten-kube-names-regex-match.")),
 		ShellVar: flag.String(
 			"shell-var",
 			"",

--- a/segment-kube.go
+++ b/segment-kube.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	pwl "github.com/justjanne/powerline-go/powerline"
 	"io/ioutil"
 	"os"
 	"path"
@@ -10,6 +9,8 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+
+	pwl "github.com/justjanne/powerline-go/powerline"
 
 	"gopkg.in/yaml.v2"
 )
@@ -96,6 +97,13 @@ func segmentKube(p *powerline) []pwl.Segment {
 	if arnMatches := arnRe.FindStringSubmatch(cluster); arnMatches != nil && *p.args.ShortenEKSNames {
 		cluster = arnMatches[1]
 	}
+
+	// Shorten Kubernetes cluster names using a custom regex and optionally a custom string template
+	if *p.args.ShortenKubeNamesRegexMatch != "" {
+		nameRe := regexp.MustCompile(*p.args.ShortenKubeNamesRegexMatch)
+		cluster = nameRe.ReplaceAllString(cluster, *p.args.ShortenKubeNamesRegexTemplate)
+	}
+
 	segments := []pwl.Segment{}
 	// Only draw the icon once
 	kubeIconHasBeenDrawnYet := false


### PR DESCRIPTION
Adds two new flags:
* - `-shorten-kube-names-regex-match`
* - `-shorten-kube-names-regex-template` (defaults to `${1}`)

Examples:

Assume a kubernetes cluster named `myorg-region-profile-cluster-01`

Using the default template:
```console
powerline-go -shorten-kube-names-regex-match '^myorg-\w+-\w+-(.*)'
```
result: `cluster-01`

Using a custom template:
```console
powerline-go -shorten-kube-names-regex-match '^myorg-(\w+)-\w+-(.*)' -shorten-kube-names-regex-template '${1}/${2}'
```
result: `region/cluster-01`