### PR TITLE
Add Openshift cluster context shortening

### DIFF
--- a/args.go
+++ b/args.go
@@ -33,6 +33,7 @@ type arguments struct {
 	IgnoreRepos            *string
 	ShortenGKENames        *bool
 	ShortenEKSNames        *bool
+	ShortenOpenshiftNames  *bool
 	ShellVar               *string
 	ShellVarNoWarnEmpty    *bool
 	TrimADDomain           *bool
@@ -166,6 +167,10 @@ var args = arguments{
 		"shorten-eks-names",
 		defaults.ShortenEKSNames,
 		comments("Shortens names for EKS Kube clusters.")),
+	ShortenOpenshiftNames: flag.Bool(
+		"shorten-openshift-names",
+		defaults.ShortenOpenshiftNames,
+		comments("Shortens names for Openshift Kube clusters.")),
 	ShellVar: flag.String(
 		"shell-var",
 		defaults.ShellVar,

--- a/config.go
+++ b/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	IgnoreRepos            []string  `json:"ignore-repos"`
 	ShortenGKENames        bool      `json:"shorten-gke-names"`
 	ShortenEKSNames        bool      `json:"shorten-eks-names"`
+	ShortenOpenshiftNames  bool      `json:"shorten-openshift-names"`
 	ShellVar               string    `json:"shell-var"`
 	ShellVarNoWarnEmpty    bool      `json:"shell-var-no-warn-empty"`
 	TrimADDomain           bool      `json:"trim-ad-domain"`

--- a/main.go
+++ b/main.go
@@ -183,6 +183,8 @@ func main() {
 			cfg.ShortenGKENames = *args.ShortenGKENames
 		case "shorten-eks-names":
 			cfg.ShortenEKSNames = *args.ShortenEKSNames
+		case "shorten-openshift-names":
+			cfg.ShortenOpenshiftNames = *args.ShortenOpenshiftNames
 		case "shell-var":
 			cfg.ShellVar = *args.ShellVar
 		case "shell-var-no-warn-empty":

--- a/segment-kube.go
+++ b/segment-kube.go
@@ -83,6 +83,21 @@ func segmentKube(p *powerline) []pwl.Segment {
 		}
 	}
 
+	// When you use openshift your clusters may look something like namespace/portal-url:port/user,
+	// instead I want it to read as `portal-url`.
+	// So we ensure there are three segments split by / and then choose the middle part,
+	// we also remove the port number from the result.
+	if p.cfg.ShortenOpenshiftNames {
+		segments := strings.Split(cluster, "/")
+		if len(segments) == 3 {
+			cluster = segments[1]
+			idx := strings.IndexByte(cluster, ':')
+			if idx != -1 {
+				cluster = cluster[0:idx]
+			}
+		}
+	}
+
 	// With AWS EKS, cluster names are ARNs; it makes more sense to shorten them
 	// so "eks-infra" instead of "arn:aws:eks:us-east-1:XXXXXXXXXXXX:cluster/eks-infra
 	const arnRegexString string = "^arn:aws:eks:[[:alnum:]-]+:[[:digit:]]+:cluster/(.*)$"


### PR DESCRIPTION
MR allows to shorten Openshift k8s contexts generated by `oc login <url>` command.