### PR TITLE
Allow node indicator to be overridden

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -83,6 +83,7 @@ var defaults = Config{
 			RepoStashed:    "\u2691",
 
 			VenvIndicator: "\uE235",
+			NodeIndicator: "\u2B22",
 		},
 		"patched": {
 			Lock:                 "\uE0A2",
@@ -104,6 +105,7 @@ var defaults = Config{
 			RepoStashed:    "\u2691",
 
 			VenvIndicator: "\uE235",
+			NodeIndicator: "\u2B22",
 		},
 		"flat": {
 			RepoDetached:   "\u2693",
@@ -116,6 +118,7 @@ var defaults = Config{
 			RepoStashed:    "\u2691",
 
 			VenvIndicator: "\uE235",
+			NodeIndicator: "\u2B22",
 		},
 	},
 	Shells: ShellMap{

--- a/segment-node.go
+++ b/segment-node.go
@@ -54,7 +54,7 @@ func segmentNode(p *powerline) []pwl.Segment {
 	if nodeVersion != "" {
 		segments = append(segments, pwl.Segment{
 			Name:       "node",
-			Content:    "\u2B22 " + nodeVersion,
+			Content:    p.symbols.NodeIndicator + " " + nodeVersion,
 			Foreground: p.theme.NodeVersionFg,
 			Background: p.theme.NodeVersionBg,
 		})
@@ -63,7 +63,7 @@ func segmentNode(p *powerline) []pwl.Segment {
 	if packageVersion != "" {
 		segments = append(segments, pwl.Segment{
 			Name:       "node-segment",
-			Content:    packageVersion + " \u2B22",
+			Content:    packageVersion + " " + p.symbols.NodeIndicator,
 			Foreground: p.theme.NodeFg,
 			Background: p.theme.NodeBg,
 		})

--- a/themes.go
+++ b/themes.go
@@ -21,6 +21,7 @@ type SymbolTemplate struct {
 	RepoStashed    string
 
 	VenvIndicator string
+	NodeIndicator string
 }
 
 // Theme definitions


### PR DESCRIPTION
This commit sets up a pattern for declaring and overriding segment-specific indicators via, e.g., configuration (`~/.config/powerline-go/config.json`) such as:

```json
{
  "modules": [ "perms", "cwd", "node", "git", "jobs", "root" ],
  "mode": "default",
  "modes": {
    "default": {
      "NodeIndicator":    "\uE781"
    }
  }
}
```

Also re: testing, I've been happily using this locally for the past ten days. Works like a charm.