### PR TITLE
Do not render node package segment if no version found

### DIFF
--- a/segment-node.go
+++ b/segment-node.go
@@ -32,7 +32,7 @@ func getPackageVersion() string {
 	if stat.IsDir() {
 		return ""
 	}
-	pkg := packageJSON{"!"}
+	pkg := packageJSON{""}
 	raw, err := ioutil.ReadFile(pkgfile)
 	if err != nil {
 		return ""


### PR DESCRIPTION
Do this instead of rendering the segment with the default value of `!`, the intent of which isn't terribly clear.