### PR TITLE
make foreground color bold

### DIFF
--- a/powerline.go
+++ b/powerline.go
@@ -185,7 +185,7 @@ func (p *powerline) color(prefix string, code uint8) string {
 }
 
 func (p *powerline) fgColor(code uint8) string {
-	return p.color("38", code)
+	return p.color("1;38", code)
 }
 
 func (p *powerline) bgColor(code uint8) string {


### PR DESCRIPTION
As asked in https://github.com/justjanne/powerline-go/issues/84

Does anyone dislike the idea of just making the font always bold? It looks better in my opinion, and it seems to be the norm for most powerline setups. (https://www.google.com/search?q=powerline+bash&tbm=isch)

I've been carrying this patch for a while on my PCs.
![image](https://user-images.githubusercontent.com/2379774/163017441-9d161103-af1f-4196-8d46-04386e257263.png)
First prompt is current behavior. Second prompt is with the bold patch.