### PR TITLE
Add support for DOCKER_CONTEXT environment variable

### DIFF
--- a/segment-docker_context.go
+++ b/segment-docker_context.go
@@ -17,15 +17,20 @@ func segmentDockerContext(p *powerline) []pwl.Segment {
 	home, _ := os.LookupEnv("HOME")
 	contextFolder := filepath.Join(home, ".docker", "contexts")
 	configFile := filepath.Join(home, ".docker", "config.json")
+	contextEnvVar := os.Getenv("DOCKER_CONTEXT")
 
-	stat, err := os.Stat(contextFolder)
-	if err == nil && stat.IsDir() {
-		dockerConfigFile, err := ioutil.ReadFile(configFile)
-		if err == nil {
-			var dockerConfig DockerContextConfig
-			err = json.Unmarshal(dockerConfigFile, &dockerConfig)
-			if err == nil && dockerConfig.CurrentContext != "" {
-				context = dockerConfig.CurrentContext
+	if contextEnvVar != "" {
+		context = contextEnvVar
+	} else {
+		stat, err := os.Stat(contextFolder)
+		if err == nil && stat.IsDir() {
+			dockerConfigFile, err := ioutil.ReadFile(configFile)
+			if err == nil {
+				var dockerConfig DockerContextConfig
+				err = json.Unmarshal(dockerConfigFile, &dockerConfig)
+				if err == nil && dockerConfig.CurrentContext != "" {
+					context = dockerConfig.CurrentContext
+				}
 			}
 		}
 	}
@@ -37,7 +42,7 @@ func segmentDockerContext(p *powerline) []pwl.Segment {
 
 	return []pwl.Segment{{
 		Name:       "docker-context",
-		Content:    "🐳" + context,
+		Content:    context,
 		Foreground: p.theme.PlEnvFg,
 		Background: p.theme.PlEnvBg,
 	}}


### PR DESCRIPTION
This PR adds support for the `DOCKER_CONTEXT` environment variable, which will override the context specified by the `docker context use` command when setting the Docker context. Accordingly, `segment-docker_context.go` is changed by this PR to use `DOCKER_CONTEXT` if specified, and use the context specified in the Docker configuration file if the environment variable is not set (the same order Docker itself uses to determine context).

Fixes #350.