### PR TITLE
Fixes #129, make use of windows git.exe on /mnt/* directory(works only WSL)

### DIFF
--- a/segment-git.go
+++ b/segment-git.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"io/ioutil"
 
 	pwl "github.com/justjanne/powerline-go/powerline"
 )
@@ -115,8 +116,21 @@ func isWinDir() bool {
 	return r.MatchString(pwd)
 }
 
+func isWSL() bool {
+	f, err := os.Open("/proc/version")
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(b), "microsoft")
+}
+
 func runGitCommand(cmd string, args ...string) (string, error) {
-	if cmd == "git" && isWinDir() {
+	if cmd == "git" && isWSL() && isWinDir() {
 		cmd = "git.exe"
 	}
 	command := exec.Command(cmd, args...)

--- a/segment-git.go
+++ b/segment-git.go
@@ -109,7 +109,16 @@ var gitProcessEnv = func() []string {
 	return result
 }()
 
+func isWinDir() bool {
+	pwd, _ := os.Getwd()
+	r := regexp.MustCompile(`^/mnt/`)
+	return r.MatchString(pwd)
+}
+
 func runGitCommand(cmd string, args ...string) (string, error) {
+	if cmd == "git" && isWinDir() {
+		cmd = "git.exe"
+	}
 	command := exec.Command(cmd, args...)
 	command.Env = gitProcessEnv
 	out, err := command.Output()


### PR DESCRIPTION
WSL2's `git status` is really slow.
Then I used https://github.com/microsoft/WSL/issues/4401 's idea(= using git.exe when dir on windows).
That improved from 15sec to around 2sec on my project.

Fixes #129.