### PR TITLE
add segment-shlvl

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,12 +248,12 @@ Usage of powerline-go:
          (default "patched")
   -modules string
          The list of modules to load, separated by ','
-         (valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl)
+         (valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, shlvl, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl)
          Unrecognized modules will be invoked as 'powerline-go-MODULE' executable plugins and should output a (possibly empty) list of JSON objects that unmarshal to powerline-go's Segment structs.
          (default "venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root")
   -modules-right string
          The list of modules to load anchored to the right, for shells that support it, separated by ','
-         (valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, wsl)
+         (valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, shlvl, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, wsl)
          Unrecognized modules will be invoked as 'powerline-go-MODULE' executable plugins and should output a (possibly empty) list of JSON objects that unmarshal to powerline-go's Segment structs.
   -newline
          Show the prompt on a new line
@@ -266,7 +266,7 @@ Usage of powerline-go:
          Use '~' for your home dir. You may need to escape this character to avoid shell substitution.
   -priority string
          Segments sorted by priority, if not enough space exists, the least priorized segments are removed first. Separate with ','
-         (valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl)
+         (valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, shlvl, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl)
          (default "root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit,cwd-path")
   -shell string
          Set this to your shell type

--- a/defaults.go
+++ b/defaults.go
@@ -262,6 +262,9 @@ var defaults = Config{
 			ShEnvFg: 15,
 			ShEnvBg: 130,
 
+			ShLvlFg: 231,
+			ShLvlBg: 55,
+
 			NodeFg:        15,
 			NodeBg:        40,
 			NodeVersionFg: 40,

--- a/main.go
+++ b/main.go
@@ -100,6 +100,7 @@ var modules = map[string]func(*powerline) []pwl.Segment{
 	"rvm":                 segmentRvm,
 	"shell-var":           segmentShellVar,
 	"shenv":               segmentShEnv,
+	"shlvl":               segmentShlvl,
 	"ssh":                 segmentSSH,
 	"termtitle":           segmentTermTitle,
 	"terraform-workspace": segmentTerraformWorkspace,

--- a/segment-shlvl.go
+++ b/segment-shlvl.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	pwl "github.com/justjanne/powerline-go/powerline"
+	"os"
+	"strconv"
+)
+
+func segmentShlvl(p *powerline) []pwl.Segment {
+
+	level, _ := os.LookupEnv("SHLVL")
+	leveli, err := strconv.Atoi(level)
+
+	if err != nil || leveli < 1 {
+		return []pwl.Segment{}
+	}
+	return []pwl.Segment{{
+		Name:       "shlvl",
+		Content:    level,
+		Foreground: p.theme.ShLvlFg,
+		Background: p.theme.ShLvlBg,
+	}}
+}

--- a/themes.go
+++ b/themes.go
@@ -139,6 +139,9 @@ type Theme struct {
 	ShEnvFg uint8
 	ShEnvBg uint8
 
+	ShLvlFg uint8
+	ShLvlBg uint8
+
 	NodeFg        uint8
 	NodeBg        uint8
 	NodeVersionFg uint8

--- a/themes/default.json
+++ b/themes/default.json
@@ -63,6 +63,8 @@
   "ShellVarBg": 11,
   "ShEnvFg": 15,
   "ShEnvBg": 130,
+  "ShLvlFg": 231,
+  "ShLvlBg": 55,
   "NodeFg": 15,
   "NodeBg": 40,
   "NodeVersionFg": 40,


### PR DESCRIPTION
This is my attempt at a module to display the SHLVL variable if the current shell is a subshell.
I've been using this patch for a few months, and I like it.

Right now it has no configuration options and no unicode icon. I figure it would be easier to add these things later (if needed) than to come up with something now and change it later. I'm not really even sure if it needs them.

See also https://github.com/justjanne/powerline-go/issues/290

![image](https://user-images.githubusercontent.com/2379774/180238989-e60d8491-e07d-48a5-b2d8-f8b9e858fdd6.png)
