### PR TITLE
AWS module try to use AWS_VAULT when AWS_PROFILE is not set

### DIFF
--- a/segment-aws.go
+++ b/segment-aws.go
@@ -10,7 +10,10 @@ func segmentAWS(p *powerline) []pwl.Segment {
 	profile := os.Getenv("AWS_PROFILE")
 	region := os.Getenv("AWS_DEFAULT_REGION")
 	if profile == "" {
-		return []pwl.Segment{}
+		profile = os.Getenv("AWS_VAULT")
+		if profile == "" {
+			return []pwl.Segment{}	
+		}
 	}
 	var r string
 	if region != "" {


### PR DESCRIPTION
This PR allows the AWS module to handle the AWS_VAULT env variable when AWS is used through aws-vault.
* aws-vault [explicitly unset AWS_PROFILE](https://github.com/99designs/aws-vault/issues/483#issuecomment-572026582) to avoid confusion.
 
**Before this change :**

* WHEN 
  * AWS_PROFILE env is empty 
  * AND AWS_VAULT env is not empty 
* THEN nothing displayed by powerline.

**After this change  :**

* WHEN 
  * AWS_PROFILE env is empty 
  * AND AWS_VAULT env is not empty 
* THEN the value of AWS_VAULT is used as the profile label displayed by powerline.



