### PR TITLE
More simple CICD workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ linux, darwin, windows, freebsd, netbsd, openbsd ]
         arch: [ amd64, arm64 ]
-        go-version: [ 1.20 ]
+        go-version: [ '1.20' ]
         include:
           - os: linux
             arch: arm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,14 +5,21 @@ on:
         types: [checks_requested]
     push: {}
 jobs:
-  release:
-    name: Build release binaries
+  build:
+    name: Build binaries
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ 'darwin', 'windows', 'freebsd', 'netbsd', 'openbsd' ]
-        arch: [ 'amd64' ]
-        go-version: [ '1.15', '1.16', '1.17' ]
+        os: [ linux, darwin, windows, freebsd, netbsd, openbsd ]
+        arch: [ amd64, arm64 ]
+        go-version: [ 1.20 ]
+        include:
+          - os: linux
+            arch: arm
+          - os: freebsd
+            arch: arm
+          - os: netbsd
+            arch: arm
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master
@@ -20,27 +27,10 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: ${{ matrix.go-version }}
-      - run: go build -o release/powerline-go-$GOOS-$GOARCH
+      - run: go build -o build/powerline-go-$GOOS-$GOARCH
         env:
           CGO_ENABLED: 0
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}
-  release-linux:
-    name: Build release binaries for linux
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ 'amd64', 'arm64', 'arm' ]
-        go-version: [ '1.15', '1.16', '1.17' ]
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@master
-      - name: Setup Golang
-        uses: actions/setup-go@v1
-        with:
-          go-version: ${{ matrix.go-version }}
-      - run: go build -o release/powerline-go-$GOOS-$GOARCH
-        env:
-          CGO_ENABLED: 0
-          GOOS: linux
-          GOARCH: ${{ matrix.arch }}
+      - if: matrix.os == 'linux' && matrix.arch == 'amd64'
+        run: build/powerline-go-linux-amd64 --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,100 +3,29 @@ on:
   release:
     types: [created]
 jobs:
-  release-linux:
+  release:
     name: Build release binaries for linux
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [ 'amd64', 'arm64', 'arm' ]
+        os: [ 'linux', 'darwin', 'windows', 'freebsd', 'netbsd', 'openbsd' ]
+        arch: [ 'amd64', 'arm64' ]
+        go-version: [ '1.20' ]
+        include:
+          - os: [ 'linux', 'freebsd', 'netbsd' ]
+          - arch: arm
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15'
+          go-version: '1.20'
       - run: go build -o release/powerline-go-$GOOS-$GOARCH
         env:
           CGO_ENABLED: 0
           GOOS: linux
           GOARCH: ${{ matrix.arch }}
-      - name: Upload the artifacts
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: 'release/powerline-go-*'
-  release-macos:
-    name: Build release binaries for macOS
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ 'amd64' ]
-        # arm64 for darwin is disabled as it's not currently supported by the go
-        # compiler for our use case
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@master
-      - name: Setup Golang
-        uses: actions/setup-go@v1
-        with:
-          go-version: '1.15'
-      - run: go build -o release/powerline-go-$GOOS-$GOARCH
-        env:
-          CGO_ENABLED: 0
-          GOOS: darwin
-          GOARCH: ${{ matrix.arch }}
-      - name: Upload the artifacts
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: 'release/powerline-go-*'
-  release-windows:
-    name: Build release binaries for windows
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ 'amd64' ]
-        # arm64 for windows is disabled as it's not currently supported by the
-        # go compiler for our use case
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@master
-      - name: Setup Golang
-        uses: actions/setup-go@v1
-        with:
-          go-version: '1.15'
-      - run: go build -o release/powerline-go-$GOOS-$GOARCH
-        env:
-          CGO_ENABLED: 0
-          GOOS: windows
-          GOARCH: ${{ matrix.arch }}
-      - name: Upload the artifacts
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: 'release/powerline-go-*'
-  release-bsd:
-    name: Build release binaries for BSD
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [ 'freebsd', 'netbsd', 'openbsd' ]
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@master
-      - name: Setup Golang
-        uses: actions/setup-go@v1
-        with:
-          go-version: '1.15'
-      - run: go build -o release/powerline-go-$GOOS-$GOARCH
-        env:
-          CGO_ENABLED: 0
-          GOOS: ${{ matrix.os }}
-          GOARCH: amd64
       - name: Upload the artifacts
         uses: skx/github-action-publish-binaries@master
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,19 @@ jobs:
         arch: [ 'amd64', 'arm64' ]
         go-version: [ '1.20' ]
         include:
-          - os: [ 'linux', 'freebsd', 'netbsd' ]
-          - arch: arm
+          - os: linux
+            arch: arm
+          - os: freebsd
+            arch: arm
+          - os: netbsd
+            arch: arm
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.20'
+          go-version: ${{ matrix.go-version }}
       - run: go build -o release/powerline-go-$GOOS-$GOARCH
         env:
           CGO_ENABLED: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - run: go build -o release/powerline-go-$GOOS-$GOARCH
         env:
           CGO_ENABLED: 0
-          GOOS: linux
+          GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}
       - name: Upload the artifacts
         uses: skx/github-action-publish-binaries@master


### PR DESCRIPTION
Hello,

I simplified your Github Actions workflow so it is basically one job per workflow.

The most important: I added darwin-arm64 target so it can run finally on Macbook M1!

Actually, this workflow is not good enough. Ie. "release" workflow might fail on retry when the artifact already exists.

A much better result and faster runs will be with https://goreleaser.com/ then it will be single run for all targets! If you are willing to allow me to help you with it, I'll prepare right pipeline that uses goreleaser.
