### PR TITLE
Goreleaser pipeline to build more archs and make release workflow more reliable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,42 +5,20 @@ on:
         types: [checks_requested]
     push: {}
 jobs:
-  release:
-    name: Build release binaries
+  build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [ 'darwin', 'windows', 'freebsd', 'netbsd', 'openbsd' ]
-        arch: [ 'amd64' ]
-        go-version: [ '1.15', '1.16', '1.17' ]
+    name: Build binaries
     steps:
-      - name: Checkout the repository
-        uses: actions/checkout@master
-      - name: Setup Golang
-        uses: actions/setup-go@v1
+      - uses: actions/checkout@v3
         with:
-          go-version: ${{ matrix.go-version }}
-      - run: go build -o release/powerline-go-$GOOS-$GOARCH
-        env:
-          CGO_ENABLED: 0
-          GOOS: ${{ matrix.os }}
-          GOARCH: ${{ matrix.arch }}
-  release-linux:
-    name: Build release binaries for linux
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ 'amd64', 'arm64', 'arm' ]
-        go-version: [ '1.15', '1.16', '1.17' ]
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@master
-      - name: Setup Golang
-        uses: actions/setup-go@v1
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
-      - run: go build -o release/powerline-go-$GOOS-$GOARCH
-        env:
-          CGO_ENABLED: 0
-          GOOS: linux
-          GOARCH: ${{ matrix.arch }}
+          go-version: "1.20"
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: build --clean --snapshot
+      - run: dist/powerline-go_linux_amd64_v1/powerline-go --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,103 +3,21 @@ on:
   release:
     types: [created]
 jobs:
-  release-linux:
-    name: Build release binaries for linux
+  release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ 'amd64', 'arm64', 'arm' ]
+    name: Release binaries
     steps:
-      - name: Checkout the repository
-        uses: actions/checkout@master
-      - name: Setup Golang
-        uses: actions/setup-go@v1
+      - uses: actions/checkout@v3
         with:
-          go-version: '1.15'
-      - run: go build -o release/powerline-go-$GOOS-$GOARCH
-        env:
-          CGO_ENABLED: 0
-          GOOS: linux
-          GOARCH: ${{ matrix.arch }}
-      - name: Upload the artifacts
-        uses: skx/github-action-publish-binaries@master
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: 'release/powerline-go-*'
-  release-macos:
-    name: Build release binaries for macOS
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ 'amd64' ]
-        # arm64 for darwin is disabled as it's not currently supported by the go
-        # compiler for our use case
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@master
-      - name: Setup Golang
-        uses: actions/setup-go@v1
-        with:
-          go-version: '1.15'
-      - run: go build -o release/powerline-go-$GOOS-$GOARCH
-        env:
-          CGO_ENABLED: 0
-          GOOS: darwin
-          GOARCH: ${{ matrix.arch }}
-      - name: Upload the artifacts
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: 'release/powerline-go-*'
-  release-windows:
-    name: Build release binaries for windows
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ 'amd64' ]
-        # arm64 for windows is disabled as it's not currently supported by the
-        # go compiler for our use case
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@master
-      - name: Setup Golang
-        uses: actions/setup-go@v1
-        with:
-          go-version: '1.15'
-      - run: go build -o release/powerline-go-$GOOS-$GOARCH
-        env:
-          CGO_ENABLED: 0
-          GOOS: windows
-          GOARCH: ${{ matrix.arch }}
-      - name: Upload the artifacts
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: 'release/powerline-go-*'
-  release-bsd:
-    name: Build release binaries for BSD
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [ 'freebsd', 'netbsd', 'openbsd' ]
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@master
-      - name: Setup Golang
-        uses: actions/setup-go@v1
-        with:
-          go-version: '1.15'
-      - run: go build -o release/powerline-go-$GOOS-$GOARCH
-        env:
-          CGO_ENABLED: 0
-          GOOS: ${{ matrix.os }}
-          GOARCH: amd64
-      - name: Upload the artifacts
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: 'release/powerline-go-*'

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.so
 *.dylib
 powerline-go
+/dist/
 
 # Test binary, build with `go test -c`
 *.test

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,9 @@
 project_name: powerline-go
+
 before:
   hooks:
     - go mod download
+
 builds:
   - binary: powerline-go
     env:
@@ -35,3 +37,6 @@ archives:
 
 checksum:
   name_template: checksums.txt
+
+changelog:
+  use: github

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,37 @@
+project_name: powerline-go
+before:
+  hooks:
+    - go mod download
+builds:
+  - binary: powerline-go
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - amd64
+      - arm
+      - arm64
+      - "386"
+    goos:
+      - darwin
+      - linux
+      - windows
+      - freebsd
+      - netbsd
+      - openbsd
+    ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: openbsd
+        goarch: arm
+    flags:
+      - -trimpath
+    ldflags:
+      - -s
+      - -w
+
+archives:
+  - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    format: binary
+
+checksum:
+  name_template: checksums.txt


### PR DESCRIPTION
Hi,

This PR replaces #382

It uses goreleaser then it is quite easier to add more targets. Here I added additional target for 386 CPU, so users of old machines might be happy.

For releasing binaries I kept the schema that artifacts are unpacked binaries with one exception that Windows binaries have .exe suffix.

Additionally checksums file is added so it will help to validate the artifacts by some installers (brew, asdf)