### PR TITLE
CI: Run release workflow on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: Release
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - v*
+permissions:
+  contents: write
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hello,

I fixed #383: the workflow for releases: it should be triggered now on `git tag`. It is the same as in the documentation: https://goreleaser.com/ci/actions/

I already implemented this workflow for my project and works as expected: see https://github.com/dex4er/gitlab-download-release/actions/runs/5074742261