### PR TITLE
Fix for empty string value from pyvenv.cfg parsing

### DIFF
--- a/segment-virtualenv.go
+++ b/segment-virtualenv.go
@@ -16,7 +16,14 @@ func segmentVirtualEnv(p *powerline) []pwl.Segment {
 		if env != "" {
 			cfg, err := ini.Load(path.Join(env, "pyvenv.cfg"))
 			if err == nil {
-				env = cfg.Section("").Key("prompt").String()
+				// python >= 3.6 the venv module will not insert a prompt
+				// key unless the `--prompt` flag is passed to the module
+				// or if calling with the prompt arg EnvBuilder
+				// otherwise env evaluates to an empty string, per return
+				// of ini.File.Section.Key
+				if pyEnv := cfg.Section("").Key("prompt").String(); len(pyEnv) > 0 {
+					env = pyEnv
+				}
 			}
 		}
 	}

--- a/segment-virtualenv.go
+++ b/segment-virtualenv.go
@@ -21,7 +21,7 @@ func segmentVirtualEnv(p *powerline) []pwl.Segment {
 				// or if calling with the prompt arg EnvBuilder
 				// otherwise env evaluates to an empty string, per return
 				// of ini.File.Section.Key
-				if pyEnv := cfg.Section("").Key("prompt").String(); len(pyEnv) > 0 {
+				if pyEnv := cfg.Section("").Key("prompt").String(); pyEnv != "" {
 					env = pyEnv
 				}
 			}


### PR DESCRIPTION
`*ini.File.Section.Key` will return a zero-length value (`string` in this case since it's cast to `string`) which evaluates to an empty `env` and then `envName` value.

Here we maintain the same functionality but check if the value is empty, if empty retain the value from `VIRTUAL_ENV` for `env`.

This fixes https://github.com/justjanne/powerline-go/issues/373 