### PR TITLE
Adding venv check for VIRTUAL_ENV_PROMPT and assuring an empty 'prompt…

### DIFF
--- a/segment-virtualenv.go
+++ b/segment-virtualenv.go
@@ -12,10 +12,17 @@ import (
 func segmentVirtualEnv(p *powerline) []pwl.Segment {
 	var env string
 	if env == "" {
+		// honor the $VIRTUAL_ENV_PATH first
+		env, _ = os.LookupEnv("VIRTUAL_ENV_PATH")
+	}
+	if env == "" {
 		env, _ = os.LookupEnv("VIRTUAL_ENV")
 		if env != "" {
 			cfg, err := ini.Load(path.Join(env, "pyvenv.cfg"))
-			if err == nil {
+			// in the case of a "prompt" value not being set in cfg,
+			// Key() will create an empty value and return it. this
+			// obliterates the env derived from VIRTUAL_ENV
+			if err == nil && cfg.Section("").HasKey("prompt") {
 				env = cfg.Section("").Key("prompt").String()
 			}
 		}


### PR DESCRIPTION
…' field doens't erase a valid venv.

Specific issues:

1. No check for VIRTUAL_ENV_PROMPT.
2. Logic error looking for "prompt" after successfully loading "pyvenv.cfg", where that config file doesn't have that key defined. (Side note: Key() will create a new key with an empty value, according to the source.)

I have patched and tested "on my own machine".