### PR TITLE
Make more segment indicators configurable

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -83,9 +83,10 @@ var defaults = Config{
 			RepoConflicted: "\u273C",
 			RepoStashed:    "\u2691",
 
-			VenvIndicator: "\uE235",
-			NodeIndicator: "\u2B22",
-			RvmIndicator:  "\uE92B",
+			NixShellIndicator:  "\uF313",
+			NodeIndicator:      "\u2B22",
+			RvmIndicator:       "\uE92B",
+			VenvIndicator:      "\uE235",
 		},
 		"patched": {
 			Lock:                 "\uE0A2",
@@ -106,9 +107,10 @@ var defaults = Config{
 			RepoConflicted: "\u273C",
 			RepoStashed:    "\u2691",
 
-			VenvIndicator: "\uE235",
-			NodeIndicator: "\u2B22",
-			RvmIndicator:  "\uE92B",
+			NixShellIndicator:  "\uF313",
+			NodeIndicator:      "\u2B22",
+			RvmIndicator:       "\uE92B",
+			VenvIndicator:      "\uE235",
 		},
 		"flat": {
 			RepoDetached:   "\u2693",
@@ -120,9 +122,10 @@ var defaults = Config{
 			RepoConflicted: "\u273C",
 			RepoStashed:    "\u2691",
 
-			VenvIndicator: "\uE235",
-			NodeIndicator: "\u2B22",
-			RvmIndicator:  "\uE92B",
+			NixShellIndicator:  "\uF313",
+			NodeIndicator:      "\u2B22",
+			RvmIndicator:       "\uE92B",
+			VenvIndicator:      "\uE235",
 		},
 	},
 	Shells: ShellMap{

--- a/defaults.go
+++ b/defaults.go
@@ -83,6 +83,7 @@ var defaults = Config{
 			RepoConflicted: "\u273C",
 			RepoStashed:    "\u2691",
 
+			KubeIndicator:      "\u2388",
 			NixShellIndicator:  "\uF313",
 			NodeIndicator:      "\u2B22",
 			RvmIndicator:       "\uE92B",
@@ -107,6 +108,7 @@ var defaults = Config{
 			RepoConflicted: "\u273C",
 			RepoStashed:    "\u2691",
 
+			KubeIndicator:      "\u2388",
 			NixShellIndicator:  "\uF313",
 			NodeIndicator:      "\u2B22",
 			RvmIndicator:       "\uE92B",
@@ -122,6 +124,7 @@ var defaults = Config{
 			RepoConflicted: "\u273C",
 			RepoStashed:    "\u2691",
 
+			KubeIndicator:      "\u2388",
 			NixShellIndicator:  "\uF313",
 			NodeIndicator:      "\u2B22",
 			RvmIndicator:       "\uE92B",

--- a/defaults.go
+++ b/defaults.go
@@ -83,6 +83,7 @@ var defaults = Config{
 			RepoConflicted: "\u273C",
 			RepoStashed:    "\u2691",
 
+			DotEnvIndicator:    "\u2235",
 			KubeIndicator:      "\u2388",
 			NixShellIndicator:  "\uF313",
 			NodeIndicator:      "\u2B22",
@@ -108,6 +109,7 @@ var defaults = Config{
 			RepoConflicted: "\u273C",
 			RepoStashed:    "\u2691",
 
+			DotEnvIndicator:    "\u2235",
 			KubeIndicator:      "\u2388",
 			NixShellIndicator:  "\uF313",
 			NodeIndicator:      "\u2B22",
@@ -124,6 +126,7 @@ var defaults = Config{
 			RepoConflicted: "\u273C",
 			RepoStashed:    "\u2691",
 
+			DotEnvIndicator:    "\u2235",
 			KubeIndicator:      "\u2388",
 			NixShellIndicator:  "\uF313",
 			NodeIndicator:      "\u2B22",

--- a/segment-dotenv.go
+++ b/segment-dotenv.go
@@ -21,7 +21,7 @@ func segmentDotEnv(p *powerline) []pwl.Segment {
 	}
 	return []pwl.Segment{{
 		Name:       "dotenv",
-		Content:    "\u2235",
+		Content:    p.symbols.DotEnvIndicator,
 		Foreground: p.theme.DotEnvFg,
 		Background: p.theme.DotEnvBg,
 	}}

--- a/segment-kube.go
+++ b/segment-kube.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	pwl "github.com/justjanne/powerline-go/powerline"
 	"io/ioutil"
 	"os"
@@ -113,7 +112,7 @@ func segmentKube(p *powerline) []pwl.Segment {
 		kubeIconHasBeenDrawnYet = true
 		segments = append(segments, pwl.Segment{
 			Name:       "kube-cluster",
-			Content:    fmt.Sprintf("⎈ %s", cluster),
+			Content:    p.symbols.KubeIndicator + " " + cluster,
 			Foreground: p.theme.KubeClusterFg,
 			Background: p.theme.KubeClusterBg,
 		})
@@ -122,7 +121,7 @@ func segmentKube(p *powerline) []pwl.Segment {
 	if namespace != "" {
 		content := namespace
 		if !kubeIconHasBeenDrawnYet {
-			content = fmt.Sprintf("⎈ %s", content)
+			content = p.symbols.KubeIndicator + " " + content
 		}
 		segments = append(segments, pwl.Segment{
 			Name:       "kube-namespace",

--- a/segment-nix-shell.go
+++ b/segment-nix-shell.go
@@ -13,7 +13,7 @@ func segmentNixShell(p *powerline) []pwl.Segment {
 	}
 	return []pwl.Segment{{
 		Name:       "nix-shell",
-		Content:    "\uf313",
+		Content:    p.symbols.NixShellIndicator,
 		Foreground: p.theme.NixShellFg,
 		Background: p.theme.NixShellBg,
 	}}

--- a/themes.go
+++ b/themes.go
@@ -20,6 +20,7 @@ type SymbolTemplate struct {
 	RepoConflicted string
 	RepoStashed    string
 
+	KubeIndicator     string
 	NixShellIndicator string
 	NodeIndicator     string
 	RvmIndicator      string

--- a/themes.go
+++ b/themes.go
@@ -20,6 +20,7 @@ type SymbolTemplate struct {
 	RepoConflicted string
 	RepoStashed    string
 
+	DotEnvIndicator   string
 	KubeIndicator     string
 	NixShellIndicator string
 	NodeIndicator     string

--- a/themes.go
+++ b/themes.go
@@ -20,9 +20,10 @@ type SymbolTemplate struct {
 	RepoConflicted string
 	RepoStashed    string
 
-	VenvIndicator string
-	NodeIndicator string
-	RvmIndicator  string
+	NixShellIndicator string
+	NodeIndicator     string
+	RvmIndicator      string
+	VenvIndicator     string
 }
 
 // Theme definitions


### PR DESCRIPTION
This pr makes the indicators of the following segments configurable:
- dotenv
- kube
- nix-shell