### PR TITLE
Fix typo in args.go, s/choosen/chosen

### DIFF
--- a/args.go
+++ b/args.go
@@ -200,7 +200,7 @@ var args = arguments{
 		"time",
 		defaults.Time,
 		comments("The layout string how a reference time should be represented.",
-			"The reference time is predefined and not user choosen.",
+			"The reference time is predefined and not user chosen.",
 			"Consult the golang documentation for details: https://pkg.go.dev/time#example-Time.Format")),
 	DurationMin: flag.String(
 		"duration-min",


### PR DESCRIPTION
While packaging powerline-go for Debian, our linter tool (lintian) spotted this typo.

PS. powerline-go is now in the Debian repositories and will start showing up in derivatives.