### PR TITLE
Add ability to use the FQDN as the hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ Usage of powerline-go:
          Show the older, original icon for SSH connections
   -colorize-hostname
          Colorize the hostname based on a hash of itself, or use the PLGO_HOSTNAMEFG and PLGO_HOSTNAMEBG env vars (both need to be set).
+  -fqdn-hostname
+         Use the longer fully qualified domain name as the hostname
   -condensed
          Remove spacing between segments
   -cwd-max-depth int

--- a/args.go
+++ b/args.go
@@ -10,6 +10,7 @@ type arguments struct {
 	CwdMaxDepth            *int
 	CwdMaxDirSize          *int
 	ColorizeHostname       *bool
+	FqdnHostname           *bool
 	HostnameOnlyIfSSH      *bool
 	SshAlternateIcon       *bool
 	EastAsianWidth         *bool
@@ -69,7 +70,7 @@ var args = arguments{
 	FqdnHostname: flag.Bool(
 		"fqdn-hostname",
 		defaults.FqdnHostname,
-		comments("Display the fully qualified domain name as ")),
+		comments("Use the longer fully qualified domain name as the hostname")),
 	HostnameOnlyIfSSH: flag.Bool(
 		"hostname-only-if-ssh",
 		defaults.HostnameOnlyIfSSH,

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	CwdMaxDepth            int       `json:"cwd-max-depth"`
 	CwdMaxDirSize          int       `json:"cwd-max-dir-size"`
 	ColorizeHostname       bool      `json:"colorize-hostname"`
+	FqdnHostname           bool      `json:"fqdn-hostname"`
 	HostnameOnlyIfSSH      bool      `json:"hostname-only-if-ssh"`
 	SshAlternateIcon       bool      `json:"alternate-ssh-icon"`
 	EastAsianWidth         bool      `json:"east-asian-width"`

--- a/defaults.go
+++ b/defaults.go
@@ -6,6 +6,7 @@ var defaults = Config{
 	CwdMaxDepth:            5,
 	CwdMaxDirSize:          -1,
 	ColorizeHostname:       false,
+	FqdnHostname:           false,
 	HostnameOnlyIfSSH:      false,
 	SshAlternateIcon:       false,
 	EastAsianWidth:         false,
@@ -147,7 +148,7 @@ var defaults = Config{
 			EvalPromptRightSuffix: `"`,
 		},
 		"bare": {
-			ColorTemplate: "%s",
+			ColorTemplate:    "%s",
 			RootIndicator:    "$",
 			EscapedBackslash: `\`,
 			EscapedBacktick:  "`",

--- a/main.go
+++ b/main.go
@@ -141,6 +141,8 @@ func main() {
 			cfg.CwdMaxDirSize = *args.CwdMaxDirSize
 		case "colorize-hostname":
 			cfg.ColorizeHostname = *args.ColorizeHostname
+		case "fqdn-hostname":
+			cfg.FqdnHostname = *args.FqdnHostname
 		case "hostname-only-if-ssh":
 			cfg.HostnameOnlyIfSSH = *args.HostnameOnlyIfSSH
 		case "alternate-ssh-icon":

--- a/segment-hostname.go
+++ b/segment-hostname.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 )
 
-func getHostName(fullyQualifiedDomainName string) string {
+func getHostName(fullyQualifiedDomainName string, keepFqdnHostname bool) string {
+	if keepFqdnHostname {
+		return fullyQualifiedDomainName
+	}
 	return strings.SplitN(fullyQualifiedDomainName, ".", 2)[0]
 }
 
@@ -30,7 +33,7 @@ func segmentHost(p *powerline) []pwl.Segment {
 	}
 
 	if p.cfg.ColorizeHostname {
-		hostName := getHostName(p.hostname)
+		hostName := getHostName(p.hostname, p.cfg.FqdnHostname)
 		hostPrompt = hostName
 
 		foregroundEnv, foregroundEnvErr := strconv.ParseUint(os.Getenv("PLGO_HOSTNAMEFG"), 0, 8)
@@ -49,7 +52,7 @@ func segmentHost(p *powerline) []pwl.Segment {
 		} else if p.cfg.Shell == "zsh" {
 			hostPrompt = "%m"
 		} else {
-			hostPrompt = getHostName(p.hostname)
+			hostPrompt = getHostName(p.hostname, p.cfg.FqdnHostname)
 		}
 
 		foreground = p.theme.HostnameFg


### PR DESCRIPTION
The only issue I can foresee is that perhaps powerline-go isn't able to capture the full FQDN with [`os.Hostname()`](https://github.com/dcm/powerline-go/blob/f4dae20e302bbe8bef2e7efd3559baec6599f56a/powerline.go#L65), so specifying `-fqdn-hostname` won't have any effect. I imagine that a user using this option will understand that it's not always possible to get the FQDN due to any number of things and so won't be bothered.