### PR TITLE
add segment-nats

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,12 +250,12 @@ Usage of powerline-go:
          (default "patched")
   -modules string
          The list of modules to load, separated by ','
-         (valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl, azure)
+         (valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl, azure, nats)
          Unrecognized modules will be invoked as 'powerline-go-MODULE' executable plugins and should output a (possibly empty) list of JSON objects that unmarshal to powerline-go's Segment structs.
          (default "venv,user,host,ssh,cwd,perms,git,hg,jobs,exit,root")
   -modules-right string
          The list of modules to load anchored to the right, for shells that support it, separated by ','
-         (valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, wsl, azure)
+         (valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, wsl, azure, nats)
          Unrecognized modules will be invoked as 'powerline-go-MODULE' executable plugins and should output a (possibly empty) list of JSON objects that unmarshal to powerline-go's Segment structs.
   -newline
          Show the prompt on a new line
@@ -268,7 +268,7 @@ Usage of powerline-go:
          Use '~' for your home dir. You may need to escape this character to avoid shell substitution.
   -priority string
          Segments sorted by priority, if not enough space exists, the least priorized segments are removed first. Separate with ','
-         (valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl, azure)
+         (valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl, azure, nats)
          (default "root,cwd,user,host,ssh,perms,git-branch,git-status,hg,jobs,exit,cwd-path")
   -shell string
          Set this to your shell type

--- a/args.go
+++ b/args.go
@@ -132,19 +132,19 @@ var args = arguments{
 		"modules",
 		strings.Join(defaults.Modules, ","),
 		commentsWithDefaults("The list of modules to load, separated by ','",
-			"(valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl, azure)",
+			"(valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl, azure, nats)",
 			"Unrecognized modules will be invoked as 'powerline-go-MODULE' executable plugins and should output a (possibly empty) list of JSON objects that unmarshal to powerline-go's Segment structs.")),
 	ModulesRight: flag.String(
 		"modules-right",
 		strings.Join(defaults.ModulesRight, ","),
 		comments("The list of modules to load anchored to the right, for shells that support it, separated by ','",
-			"(valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, wsl, azure)",
+			"(valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, wsl, azure, nats)",
 			"Unrecognized modules will be invoked as 'powerline-go-MODULE' executable plugins and should output a (possibly empty) list of JSON objects that unmarshal to powerline-go's Segment structs.")),
 	Priority: flag.String(
 		"priority",
 		strings.Join(defaults.Priority, ","),
 		commentsWithDefaults("Segments sorted by priority, if not enough space exists, the least priorized segments are removed first. Separate with ','",
-			"(valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl, azure)")),
+			"(valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl, azure, nats)")),
 	MaxWidthPercentage: flag.Int(
 		"max-width",
 		defaults.MaxWidthPercentage,

--- a/defaults.go
+++ b/defaults.go
@@ -211,6 +211,9 @@ var defaults = Config{
 			AzureFg: 15, // white
 			AzureBg: 26, // Azure blue
 
+			NatsFg: 15, // white
+			NatsBg: 39, // bright cyan
+
 			AWSFg: 15,  // white
 			AWSBg: 172, // AWS orange
 

--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ var modules = map[string]func(*powerline) []pwl.Segment{
 	"docker-context":      segmentDockerContext,
 	"dotenv":              segmentDotEnv,
 	"azure":               segmentAzure,
+	"nats":                segmentNats,
 	"duration":            segmentDuration,
 	"exit":                segmentExitCode,
 	"fossil":              segmentFossil,

--- a/segment-nats.go
+++ b/segment-nats.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	pwl "github.com/justjanne/powerline-go/powerline"
+)
+
+// utf8BOM is the UTF-8 byte order mark that some editors may add
+var natsUtf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+type natsContextInfo struct {
+	Name string `json:"name"`
+}
+
+func getNatsConfigDir() string {
+	if xdgConfig := os.Getenv("XDG_CONFIG_HOME"); xdgConfig != "" {
+		return filepath.Join(xdgConfig, "nats")
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	if runtime.GOOS == "windows" {
+		return filepath.Join(home, "AppData", "Local", "nats")
+	}
+
+	return filepath.Join(home, ".config", "nats")
+}
+
+func getNatsContextName() string {
+	if ctx := os.Getenv("NATS_CONTEXT"); ctx != "" {
+		return strings.TrimSpace(ctx)
+	}
+
+	configDir := getNatsConfigDir()
+	if configDir != "" {
+		contextFile := filepath.Join(configDir, "context.txt")
+		if data, err := os.ReadFile(contextFile); err == nil {
+			data = bytes.TrimPrefix(data, natsUtf8BOM)
+			if name := strings.TrimSpace(string(data)); name != "" {
+				return name
+			}
+		}
+	}
+
+	out, err := exec.Command("nats", "context", "info", "--json").Output()
+	if err != nil {
+		return ""
+	}
+
+	var ctx natsContextInfo
+	if err := json.Unmarshal(out, &ctx); err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(ctx.Name)
+}
+
+func segmentNats(p *powerline) []pwl.Segment {
+	name := getNatsContextName()
+	if name == "" {
+		return []pwl.Segment{}
+	}
+
+	return []pwl.Segment{{
+		Name:       "nats",
+		Content:    name,
+		Foreground: p.theme.NatsFg,
+		Background: p.theme.NatsBg,
+	}}
+}

--- a/themes.go
+++ b/themes.go
@@ -81,6 +81,9 @@ type Theme struct {
 	AzureFg uint8
 	AzureBg uint8
 
+	NatsFg uint8
+	NatsBg uint8
+
 	AWSFg uint8
 	AWSBg uint8
 


### PR DESCRIPTION
Displays active NATS CLI context name. Reads from `NATS_CONTEXT` env var / config file / or CLI invocation (as a fallback) .