### PR TITLE
feat: new segment with basic info about background tmux sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ powerline-go
 /.idea/
 
 .vscode/
+
+# direnv's environment files
+.envrc

--- a/args.go
+++ b/args.go
@@ -133,19 +133,19 @@ var args = arguments{
 		"modules",
 		strings.Join(defaults.Modules, ","),
 		commentsWithDefaults("The list of modules to load, separated by ','",
-			"(valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl, azure)",
+			"(valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, tmux, user, venv, vgo, vi-mode, wsl, azure)",
 			"Unrecognized modules will be invoked as 'powerline-go-MODULE' executable plugins and should output a (possibly empty) list of JSON objects that unmarshal to powerline-go's Segment structs.")),
 	ModulesRight: flag.String(
 		"modules-right",
 		strings.Join(defaults.ModulesRight, ","),
 		comments("The list of modules to load anchored to the right, for shells that support it, separated by ','",
-			"(valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, wsl, azure)",
+			"(valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, tmux, user, venv, vgo, wsl, azure)",
 			"Unrecognized modules will be invoked as 'powerline-go-MODULE' executable plugins and should output a (possibly empty) list of JSON objects that unmarshal to powerline-go's Segment structs.")),
 	Priority: flag.String(
 		"priority",
 		strings.Join(defaults.Priority, ","),
 		commentsWithDefaults("Segments sorted by priority, if not enough space exists, the least priorized segments are removed first. Separate with ','",
-			"(valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, user, venv, vgo, vi-mode, wsl, azure)")),
+			"(valid choices: aws, bzr, cwd, direnv, docker, docker-context, dotenv, duration, exit, fossil, gcp, git, gitlite, goenv, hg, host, jobs, kube, load, newline, nix-shell, node, perlbrew, perms, plenv, rbenv, root, rvm, shell-var, shenv, ssh, svn, termtitle, terraform-workspace, time, tmux, user, venv, vgo, vi-mode, wsl, azure)")),
 	MaxWidthPercentage: flag.Int(
 		"max-width",
 		defaults.MaxWidthPercentage,

--- a/config.go
+++ b/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	ShortenOpenshiftNames  bool      `json:"shorten-openshift-names"`
 	ShellVar               string    `json:"shell-var"`
 	ShellVarNoWarnEmpty    bool      `json:"shell-var-no-warn-empty"`
+	SimpleTmux             bool      `json:"simple-tmux"`
 	TrimADDomain           bool      `json:"trim-ad-domain"`
 	PathAliases            AliasMap  `json:"path-aliases"`
 	Duration               string    `json:"-"`

--- a/defaults.go
+++ b/defaults.go
@@ -65,6 +65,7 @@ var defaults = Config{
 	Eval:                 false,
 	Condensed:            false,
 	IgnoreWarnings:       false,
+	SimpleTmux:           true,
 	Modes: SymbolMap{
 		"compatible": {
 			Lock:                 "RO",
@@ -90,6 +91,10 @@ var defaults = Config{
 			NodeIndicator:      "\u2B22",
 			RvmIndicator:       "\uE92B",
 			VenvIndicator:      "\uE235",
+
+			TmuxIndicator:      "TMUX",
+			TmuxOff:            "off",
+			TmuxOn:             "on",
 		},
 		"patched": {
 			Lock:                 "\uE0A2",
@@ -116,6 +121,10 @@ var defaults = Config{
 			NodeIndicator:      "\u2B22",
 			RvmIndicator:       "\uE92B",
 			VenvIndicator:      "\uE235",
+
+			TmuxIndicator:      "\u29C9",
+			TmuxOff:            "\u2B58",
+			TmuxOn:             "\u23FD",
 		},
 		"flat": {
 			RepoDetached:   "\u2693",
@@ -268,6 +277,9 @@ var defaults = Config{
 
 			TimeFg: 15,
 			TimeBg: 236,
+
+			TmuxFg: 7,
+			TmuxBg: 38,
 
 			ShellVarFg: 52,
 			ShellVarBg: 11,
@@ -648,6 +660,9 @@ var defaults = Config{
 			TimeFg: 236,
 			TimeBg: 15,
 
+			TmuxFg: 7,
+			TmuxBg: 38,
+
 			ShEnvFg: 130,
 			ShEnvBg: 15,
 
@@ -987,6 +1002,8 @@ var defaults = Config{
 			PlEnvBg:            4,
 			TimeFg:             15,
 			TimeBg:             0,
+			TmuxFg:             7,
+			TmuxBg:             38,
 			ShellVarFg:         1,
 			ShellVarBg:         11,
 			ShEnvFg:            15,
@@ -1328,6 +1345,8 @@ var defaults = Config{
 			PlEnvBg:            4,
 			TimeFg:             15,
 			TimeBg:             0,
+			TmuxFg:             7,
+			TmuxBg:             38,
 			ShellVarFg:         1,
 			ShellVarBg:         11,
 			ShEnvFg:            15,
@@ -1670,6 +1689,8 @@ var defaults = Config{
 			PlEnvBg:            gruvbox_faded_green, // match virtualenv
 			TimeFg:             gruvbox_light2,
 			TimeBg:             gruvbox_dark4,
+			TmuxFg:             gruvbox_light2,
+			TmuxBg:             gruvbox_neutral_aqua,
 			ShellVarFg:         gruvbox_light0,       // match ssh-fg
 			ShellVarBg:         gruvbox_faded_purple, // match ssh-bg
 			NodeFg:             gruvbox_light0,       // match virtualenv

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ var modules = map[string]func(*powerline) []pwl.Segment{
 	"termtitle":           segmentTermTitle,
 	"terraform-workspace": segmentTerraformWorkspace,
 	"time":                segmentTime,
+	"tmux":                segmentTmux,
 	"node":                segmentNode,
 	"user":                segmentUser,
 	"venv":                segmentVirtualEnv,

--- a/segment-tmux.go
+++ b/segment-tmux.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	pwl "github.com/justjanne/powerline-go/powerline"
+)
+
+type tmuxState struct {
+	clients  int
+	sessions int
+	attached int
+	p        *powerline
+}
+
+func (ts *tmuxState) isOn() bool {
+	return ts.clients+ts.sessions+ts.attached > 0
+}
+
+func (ts *tmuxState) status() string {
+	var tOn string = fmt.Sprintf("%s %s", ts.p.symbols.TmuxIndicator, ts.p.symbols.TmuxOn)
+	var tOff string = fmt.Sprintf("%s %s", ts.p.symbols.TmuxIndicator, ts.p.symbols.TmuxOff)
+
+	if !ts.p.cfg.SimpleTmux {
+		tOn = fmt.Sprintf("%s c:%2d s:%2d a:%2d", ts.p.symbols.TmuxIndicator, ts.clients, ts.sessions, ts.attached)
+		tOff = ""
+	}
+
+	if ts.isOn() {
+		return tOn
+	}
+
+	return tOff
+}
+
+func runTmuxCmd(parameters ...string) (string, error) {
+	output, err := exec.Command("tmux", parameters...).Output()
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
+}
+
+func countLines(input string, countSum bool) (int, int) {
+	var cntr, sum int
+
+	lines := strings.Split(input, "\n")
+
+	for _, l := range lines {
+
+		if len(l) == 0 {
+			continue
+		}
+
+		cntr++
+
+		if countSum {
+			val, _ := strconv.Atoi(l)
+			sum = +val
+		}
+	}
+
+	return cntr, sum
+}
+
+func updateClientNum(ts *tmuxState) {
+	output, err := runTmuxCmd("list-clients", "-F", "#{session_windows}")
+
+	if err == nil {
+		ts.clients, _ = countLines(output, false)
+	}
+}
+
+func updateSessionNum(ts *tmuxState) {
+	output, err := runTmuxCmd("list-sessions", "-F", "#{session_attached}")
+
+	if err == nil {
+		ts.sessions, ts.attached = countLines(output, true)
+	}
+}
+
+func segmentTmux(p *powerline) []pwl.Segment {
+	ts := &tmuxState{p: p}
+
+	if _, exists := os.LookupEnv("TMUX"); !exists {
+		updateClientNum(ts)
+		updateSessionNum(ts)
+
+		if tc := ts.status(); len(tc) > 0 {
+			return []pwl.Segment{{
+				Name:       "tmux",
+				Content:    tc,
+				Foreground: p.theme.TmuxFg,
+				Background: p.theme.TmuxBg,
+			}}
+		}
+	}
+
+	return []pwl.Segment{}
+}

--- a/themes.go
+++ b/themes.go
@@ -26,6 +26,10 @@ type SymbolTemplate struct {
 	NodeIndicator     string
 	RvmIndicator      string
 	VenvIndicator     string
+
+	TmuxIndicator     string
+	TmuxOff           string
+	TmuxOn            string
 }
 
 // Theme definitions
@@ -138,6 +142,9 @@ type Theme struct {
 
 	TimeFg uint8
 	TimeBg uint8
+
+	TmuxFg uint8
+	TmuxBg uint8
 
 	ShellVarFg uint8
 	ShellVarBg uint8

--- a/themes/default.json
+++ b/themes/default.json
@@ -59,6 +59,8 @@
   "PlEnvBg": 32,
   "TimeFg": 15,
   "TimeBg": 236,
+  "TmuxFg": 7,
+  "TmuxBg": 50,
   "ShellVarFg": 52,
   "ShellVarBg": 11,
   "ShEnvFg": 15,


### PR DESCRIPTION
New segment indicating if there are any tmux sessions waiting in the background. It has two modes of operation:

- simple, where it shows if any background session exists using just on/off indicator,
- detailed, where it shows number of sessions, clients and clients attached.

The segment is displayed only outside of a tmux session. Showing it inside is just redundant (if we are in tmux, we already know about it).

Rationale: one may save some effort to know if any tmux session still exists in the background without listing sessions/servers before attempt to attach them. This is useful in environments, where idling shells and connections are killed after some arbitary time.