### PR TITLE
Add config.json-only options: 'kube-namespace-only' and 'git-show-tag'

### DIFF
--- a/config.go
+++ b/config.go
@@ -42,6 +42,8 @@ type Config struct {
 	ShortenGKENames        bool      `json:"shorten-gke-names"`
 	ShortenEKSNames        bool      `json:"shorten-eks-names"`
 	ShortenOpenshiftNames  bool      `json:"shorten-openshift-names"`
+	KubeNamespaceOnly      bool      `json:"kube-namespace-only"`
+	GitShowTag             bool      `json:"git-show-tag"`
 	ShellVar               string    `json:"shell-var"`
 	ShellVarNoWarnEmpty    bool      `json:"shell-var-no-warn-empty"`
 	TrimADDomain           bool      `json:"trim-ad-domain"`

--- a/segment-git.go
+++ b/segment-git.go
@@ -120,7 +120,38 @@ func parseGitBranchInfo(status []string) map[string]string {
 	return groupDict(branchRegex, status[0])
 }
 
+func getGitTagAtHead() string {
+	// check reflog for what was checked out
+	reflog, err := runGitCommand("git", "--no-optional-locks", "reflog", "-1", "--format=%gs")
+	if err != nil {
+		return ""
+	}
+	reflog = strings.TrimSpace(reflog)
+	if !strings.HasPrefix(reflog, "checkout: moving from ") {
+		return ""
+	}
+	target := reflog[strings.LastIndex(reflog, " to ")+4:]
+
+	// verify it's a tag that points at HEAD
+	tags, err := runGitCommand("git", "--no-optional-locks", "tag", "--points-at", "HEAD")
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(strings.TrimSpace(tags), "\n") {
+		if line == target {
+			return target
+		}
+	}
+	return ""
+}
+
 func getGitDetachedBranch(p *powerline) string {
+	if p.cfg.GitShowTag {
+		if tag := getGitTagAtHead(); tag != "" {
+			return fmt.Sprintf("%s %s", p.symbols.RepoDetached, tag)
+		}
+	}
+
 	out, err := runGitCommand("git", "--no-optional-locks", "rev-parse", "--short", "HEAD")
 	if err != nil {
 		out, err := runGitCommand("git", "--no-optional-locks", "symbolic-ref", "--short", "HEAD")

--- a/segment-kube.go
+++ b/segment-kube.go
@@ -108,7 +108,7 @@ func segmentKube(p *powerline) []pwl.Segment {
 	segments := []pwl.Segment{}
 	// Only draw the icon once
 	kubeIconHasBeenDrawnYet := false
-	if cluster != "" {
+	if cluster != "" && !p.cfg.KubeNamespaceOnly {
 		kubeIconHasBeenDrawnYet = true
 		segments = append(segments, pwl.Segment{
 			Name:       "kube-cluster",


### PR DESCRIPTION
**Note:** PR created with AI assistance but obviously I checked the git show tag feature.
Can't check kube 'cause I don't have a local kube env (can't be bothered with kube outside of work).

`git-show-tag`
Show the exact tag name you checked out (via reflog + tag verification),
instead of commit SHA, when in detached HEAD state.
Works correctly in monorepos with multiple tags on the same commit.

```
default
⚓ 4a8abaa

"git-show-tag": true
⚓ v1.26

"git-show-tag": true (monorepo)
⚓ server-0.7.0
```

`kube-namespace-only`
Show only the namespace in the kube segment, hiding the cluster name.

```
default
⎈ long-cluster-fqdn  namespace

"kube-namespace-only": true
⎈ namespace
```

Both are opt-in via `~/.config/powerline-go/config.json`, no CLI flags added.